### PR TITLE
Friend 친구 신청 구현

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,10 +12,7 @@ import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { SignupDto } from './dto/signup.dto';
-import {
-  AuthResponseDto,
-  AuthTokensResponseDto,
-} from './dto/auth-response.dto';
+import { AuthResponseDto, AuthTokensResponseDto } from './dto/auth-response.dto';
 import type { AuthenticatedUser } from './interfaces/jwt-payload.interface';
 
 @ApiTags('Auth')
@@ -42,9 +39,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '토큰 재발급' })
   @ApiOkResponse({ type: AuthTokensResponseDto })
-  refresh(
-    @Body() refreshTokenDto: RefreshTokenDto,
-  ): Promise<AuthTokensResponseDto> {
+  refresh(@Body() refreshTokenDto: RefreshTokenDto): Promise<AuthTokensResponseDto> {
     return this.authService.refresh(refreshTokenDto);
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -16,10 +16,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>(
-          'JWT_ACCESS_SECRET',
-          JWT_DEFAULTS.accessSecret,
-        ),
+        secret: configService.get<string>('JWT_ACCESS_SECRET', JWT_DEFAULTS.accessSecret),
       }),
     }),
   ],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,10 +9,7 @@ import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { SignupDto } from './dto/signup.dto';
 import { AuthResponseDto, AuthTokensResponseDto } from './dto/auth-response.dto';
-import {
-  JwtAccessPayload,
-  JwtRefreshPayload,
-} from './interfaces/jwt-payload.interface';
+import { JwtAccessPayload, JwtRefreshPayload } from './interfaces/jwt-payload.interface';
 
 @Injectable()
 export class AuthService {
@@ -51,12 +48,7 @@ export class AuthService {
 
   async login(loginDto: LoginDto): Promise<AuthResponseDto> {
     const user = await this.validateCredentials(loginDto);
-    const tokens = await this.issueTokens(
-      user.id,
-      user.email,
-      user.nickname,
-      user.tokenVersion,
-    );
+    const tokens = await this.issueTokens(user.id, user.email, user.nickname, user.tokenVersion);
 
     return {
       ...tokens,
@@ -92,9 +84,7 @@ export class AuthService {
       user.tokenVersion,
     );
 
-    const nextRefreshTokenHash = await this.createRefreshTokenHash(
-      nextTokens.refreshToken,
-    );
+    const nextRefreshTokenHash = await this.createRefreshTokenHash(nextTokens.refreshToken);
     const rotated = await this.userService.rotateRefreshTokenHash(
       user.id,
       user.refreshTokenHash,
@@ -118,12 +108,7 @@ export class AuthService {
     nickname: string,
     tokenVersion: number,
   ): Promise<AuthTokensResponseDto> {
-    const tokens = await this.issueTokensWithoutPersisting(
-      userId,
-      email,
-      nickname,
-      tokenVersion,
-    );
+    const tokens = await this.issueTokensWithoutPersisting(userId, email, nickname, tokenVersion);
     const refreshTokenHash = await this.createRefreshTokenHash(tokens.refreshToken);
     await this.userService.updateRefreshTokenHash(userId, refreshTokenHash);
 
@@ -140,24 +125,12 @@ export class AuthService {
     const refreshTokenId = randomUUID();
 
     const accessToken = await this.jwtService.signAsync(
-      this.buildAccessPayload(
-        userId,
-        email,
-        nickname,
-        tokenVersion,
-        accessTokenId,
-      ),
+      this.buildAccessPayload(userId, email, nickname, tokenVersion, accessTokenId),
       this.getAccessTokenOptions(),
     );
 
     const refreshToken = await this.jwtService.signAsync(
-      this.buildRefreshPayload(
-        userId,
-        email,
-        nickname,
-        tokenVersion,
-        refreshTokenId,
-      ),
+      this.buildRefreshPayload(userId, email, nickname, tokenVersion, refreshTokenId),
       this.getRefreshTokenOptions(),
     );
 
@@ -174,19 +147,11 @@ export class AuthService {
     ]);
   }
 
-  private async verifyRefreshToken(
-    refreshToken: string,
-  ): Promise<JwtRefreshPayload> {
+  private async verifyRefreshToken(refreshToken: string): Promise<JwtRefreshPayload> {
     try {
-      const payload = await this.jwtService.verifyAsync<JwtRefreshPayload>(
-        refreshToken,
-        {
-          secret: this.configService.get<string>(
-            'JWT_REFRESH_SECRET',
-            JWT_DEFAULTS.refreshSecret,
-          ),
-        },
-      );
+      const payload = await this.jwtService.verifyAsync<JwtRefreshPayload>(refreshToken, {
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET', JWT_DEFAULTS.refreshSecret),
+      });
 
       if (payload.type !== 'refresh') {
         throw new UnauthorizedException(AUTH_ERROR_MESSAGES.invalidRefreshToken);
@@ -209,10 +174,7 @@ export class AuthService {
       throw new UnauthorizedException(AUTH_ERROR_MESSAGES.invalidCredentials);
     }
 
-    const isPasswordValid = await bcrypt.compare(
-      loginDto.password,
-      user.hashedPassword,
-    );
+    const isPasswordValid = await bcrypt.compare(loginDto.password, user.hashedPassword);
 
     if (!isPasswordValid) {
       throw new UnauthorizedException(AUTH_ERROR_MESSAGES.invalidCredentials);
@@ -257,10 +219,7 @@ export class AuthService {
 
   private getAccessTokenOptions() {
     return {
-      secret: this.configService.get<string>(
-        'JWT_ACCESS_SECRET',
-        JWT_DEFAULTS.accessSecret,
-      ),
+      secret: this.configService.get<string>('JWT_ACCESS_SECRET', JWT_DEFAULTS.accessSecret),
       jwtid: randomUUID(),
       expiresIn: this.configService.get<string>(
         'JWT_ACCESS_EXPIRES_IN',
@@ -271,10 +230,7 @@ export class AuthService {
 
   private getRefreshTokenOptions() {
     return {
-      secret: this.configService.get<string>(
-        'JWT_REFRESH_SECRET',
-        JWT_DEFAULTS.refreshSecret,
-      ),
+      secret: this.configService.get<string>('JWT_REFRESH_SECRET', JWT_DEFAULTS.refreshSecret),
       jwtid: randomUUID(),
       expiresIn: this.configService.get<string>(
         'JWT_REFRESH_EXPIRES_IN',

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsDateString, IsEmail, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsDateString,
+  IsEmail,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class SignupDto {
   @ApiProperty({

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -4,10 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserService } from '../../users/users.service';
 import { JWT_DEFAULTS } from '../auth.constants';
-import {
-  AuthenticatedUser,
-  JwtAccessPayload,
-} from '../interfaces/jwt-payload.interface';
+import { AuthenticatedUser, JwtAccessPayload } from '../interfaces/jwt-payload.interface';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -18,10 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>(
-        'JWT_ACCESS_SECRET',
-        JWT_DEFAULTS.accessSecret,
-      ),
+      secretOrKey: configService.get<string>('JWT_ACCESS_SECRET', JWT_DEFAULTS.accessSecret),
     });
   }
 

--- a/src/commons/entities/base.entity.ts
+++ b/src/commons/entities/base.entity.ts
@@ -2,11 +2,11 @@ import { CreateDateColumn, DeleteDateColumn, UpdateDateColumn } from 'typeorm';
 
 export class BaseTableEntity {
   @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
+  createdAt: string;
 
   @UpdateDateColumn({ name: 'updated_at', select: false })
-  updatedAt: Date;
+  updatedAt: string;
 
   @DeleteDateColumn({ name: 'deleted_at', select: false })
-  deletedAt: Date;
+  deletedAt: string;
 }

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -19,9 +19,7 @@ export class TypeOrmConfig implements TypeOrmOptionsFactory {
         synchronize: true,
         dropSchema: true,
         logging: false,
-        dataSourceFactory: async (
-          options?: TypeOrmModuleOptions,
-        ): Promise<DataSource> => {
+        dataSourceFactory: async (options?: TypeOrmModuleOptions): Promise<DataSource> => {
           const db = newDb({
             autoCreateForeignKeyIndices: true,
           });
@@ -36,9 +34,7 @@ export class TypeOrmConfig implements TypeOrmOptionsFactory {
             implementation: () => 'PostgreSQL 16.0',
           });
 
-          const dataSource = db.adapters.createTypeormDataSource(
-            options as DataSourceOptions,
-          );
+          const dataSource = db.adapters.createTypeormDataSource(options as DataSourceOptions);
 
           if (!dataSource.isInitialized) {
             await dataSource.initialize();

--- a/src/friends/dto/create-friend-request.dto.ts
+++ b/src/friends/dto/create-friend-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class CreateFriendRequestDto {
+  @ApiProperty({
+    example: 2,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  receiverId: number;
+}

--- a/src/friends/dto/friend-request-response.dto.ts
+++ b/src/friends/dto/friend-request-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FriendStatus } from '../entities/friend.entity';
+
+export class FriendRequestResponseDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  requesterId: number;
+
+  @ApiProperty()
+  receiverId: number;
+
+  @ApiProperty({ enum: FriendStatus })
+  status: FriendStatus;
+
+  @ApiProperty()
+  createdAt: string;
+}

--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -1,9 +1,5 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import {
-  ApiCreatedResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
@@ -24,9 +20,6 @@ export class FriendController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Body() createFriendRequestDto: CreateFriendRequestDto,
   ): Promise<FriendRequestResponseDto> {
-    return this.friendService.createRequest(
-      currentUser.userId,
-      createFriendRequestDto.receiverId,
-    );
+    return this.friendService.createRequest(currentUser.userId, createFriendRequestDto.receiverId);
   }
 }

--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Authenticated } from '../auth/decorators/authenticated.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
+import { FriendRequestResponseDto } from './dto/friend-request-response.dto';
+import { FriendService } from './friends.service';
+
+@ApiTags('Friend')
+@Controller('friends')
+export class FriendController {
+  constructor(private readonly friendService: FriendService) {}
+
+  @Post('requests')
+  @Authenticated()
+  @ApiOperation({ summary: '친구 신청' })
+  @ApiCreatedResponse({ type: FriendRequestResponseDto })
+  async createFriendRequest(
+    @CurrentUser() currentUser: AuthenticatedUser,
+    @Body() createFriendRequestDto: CreateFriendRequestDto,
+  ): Promise<FriendRequestResponseDto> {
+    return this.friendService.createRequest(
+      currentUser.userId,
+      createFriendRequestDto.receiverId,
+    );
+  }
+}

--- a/src/friends/friends.module.ts
+++ b/src/friends/friends.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from '../users/users.module';
 import { Friend } from './entities/friend.entity';
+import { FriendController } from './friends.controller';
+import { FriendRepository } from './friends.repository';
+import { FriendService } from './friends.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friend])],
-  controllers: [],
-  providers: [],
+  imports: [TypeOrmModule.forFeature([Friend]), UserModule],
+  controllers: [FriendController],
+  providers: [FriendRepository, FriendService],
 })
 export class FriendModule {}

--- a/src/friends/friends.repository.ts
+++ b/src/friends/friends.repository.ts
@@ -11,10 +11,7 @@ export class FriendRepository {
     private readonly friendRepository: Repository<Friend>,
   ) {}
 
-  async findActiveRelationsBetweenUsers(
-    userId: number,
-    otherUserId: number,
-  ): Promise<Friend[]> {
+  async findActiveRelationsBetweenUsers(userId: number, otherUserId: number): Promise<Friend[]> {
     return this.friendRepository
       .createQueryBuilder('friend')
       .leftJoinAndSelect('friend.requester', 'requester')
@@ -26,10 +23,7 @@ export class FriendRepository {
       .getMany();
   }
 
-  async findRestorableRequest(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<Friend | null> {
+  async findRestorableRequest(requesterId: number, receiverId: number): Promise<Friend | null> {
     return this.friendRepository
       .createQueryBuilder('friend')
       .withDeleted()
@@ -50,14 +44,8 @@ export class FriendRepository {
       .getOne();
   }
 
-  async createOrRestoreRequest(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<Friend> {
-    const restorableRequest = await this.findRestorableRequest(
-      requesterId,
-      receiverId,
-    );
+  async createOrRestoreRequest(requesterId: number, receiverId: number): Promise<Friend> {
+    const restorableRequest = await this.findRestorableRequest(requesterId, receiverId);
 
     if (restorableRequest) {
       return this.restoreRequest(restorableRequest);
@@ -74,10 +62,7 @@ export class FriendRepository {
     return (await this.findById(restoredRequest.id)) ?? restoredRequest;
   }
 
-  private async createNewRequest(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<Friend> {
+  private async createNewRequest(requesterId: number, receiverId: number): Promise<Friend> {
     const friendRequest = this.friendRepository.create({
       requester: { id: requesterId } as User,
       receiver: { id: receiverId } as User,

--- a/src/friends/friends.repository.ts
+++ b/src/friends/friends.repository.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+import { Friend, FriendStatus } from './entities/friend.entity';
+
+@Injectable()
+export class FriendRepository {
+  constructor(
+    @InjectRepository(Friend)
+    private readonly friendRepository: Repository<Friend>,
+  ) {}
+
+  async findActiveRelationsBetweenUsers(
+    userId: number,
+    otherUserId: number,
+  ): Promise<Friend[]> {
+    return this.friendRepository
+      .createQueryBuilder('friend')
+      .leftJoinAndSelect('friend.requester', 'requester')
+      .leftJoinAndSelect('friend.receiver', 'receiver')
+      .where(
+        '(requester.id = :userId AND receiver.id = :otherUserId) OR (requester.id = :otherUserId AND receiver.id = :userId)',
+        { userId, otherUserId },
+      )
+      .getMany();
+  }
+
+  async findRestorableRequest(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<Friend | null> {
+    return this.friendRepository
+      .createQueryBuilder('friend')
+      .withDeleted()
+      .leftJoinAndSelect('friend.requester', 'requester')
+      .leftJoinAndSelect('friend.receiver', 'receiver')
+      .where('requester.id = :requesterId', { requesterId })
+      .andWhere('receiver.id = :receiverId', { receiverId })
+      .andWhere('friend.deleted_at IS NOT NULL')
+      .getOne();
+  }
+
+  async findById(friendId: number): Promise<Friend | null> {
+    return this.friendRepository
+      .createQueryBuilder('friend')
+      .leftJoinAndSelect('friend.requester', 'requester')
+      .leftJoinAndSelect('friend.receiver', 'receiver')
+      .where('friend.id = :friendId', { friendId })
+      .getOne();
+  }
+
+  async createOrRestoreRequest(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<Friend> {
+    const restorableRequest = await this.findRestorableRequest(
+      requesterId,
+      receiverId,
+    );
+
+    if (restorableRequest) {
+      return this.restoreRequest(restorableRequest);
+    }
+
+    return this.createNewRequest(requesterId, receiverId);
+  }
+
+  private async restoreRequest(friendRequest: Friend): Promise<Friend> {
+    await this.friendRepository.restore(friendRequest.id);
+    friendRequest.status = FriendStatus.PENDING;
+
+    const restoredRequest = await this.friendRepository.save(friendRequest);
+    return (await this.findById(restoredRequest.id)) ?? restoredRequest;
+  }
+
+  private async createNewRequest(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<Friend> {
+    const friendRequest = this.friendRepository.create({
+      requester: { id: requesterId } as User,
+      receiver: { id: receiverId } as User,
+      status: FriendStatus.PENDING,
+    });
+
+    const savedRequest = await this.friendRepository.save(friendRequest);
+    return (await this.findById(savedRequest.id)) ?? savedRequest;
+  }
+}

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  ConflictException,
-  Injectable,
-} from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import { UserService } from '../users/users.service';
 import { Friend, FriendStatus } from './entities/friend.entity';
 import { FriendRequestResponseDto } from './dto/friend-request-response.dto';
@@ -15,10 +11,7 @@ export class FriendService {
     private readonly userService: UserService,
   ) {}
 
-  async createRequest(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<FriendRequestResponseDto> {
+  async createRequest(requesterId: number, receiverId: number): Promise<FriendRequestResponseDto> {
     await this.validateReceiver(requesterId, receiverId);
     await this.ensureRequestableRelation(requesterId, receiverId);
 
@@ -30,10 +23,7 @@ export class FriendService {
     return this.toResponse(friendRequest);
   }
 
-  private async validateReceiver(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<void> {
+  private async validateReceiver(requesterId: number, receiverId: number): Promise<void> {
     if (requesterId === receiverId) {
       throw new BadRequestException('Cannot send friend request to yourself.');
     }
@@ -41,20 +31,14 @@ export class FriendService {
     await this.userService.findActiveUserOrFail(receiverId);
   }
 
-  private async ensureRequestableRelation(
-    requesterId: number,
-    receiverId: number,
-  ): Promise<void> {
-    const existingRelations =
-      await this.friendRepository.findActiveRelationsBetweenUsers(
-        requesterId,
-        receiverId,
-      );
+  private async ensureRequestableRelation(requesterId: number, receiverId: number): Promise<void> {
+    const existingRelations = await this.friendRepository.findActiveRelationsBetweenUsers(
+      requesterId,
+      receiverId,
+    );
 
     const sameDirectionRelation = existingRelations.find(
-      (relation) =>
-        relation.requester.id === requesterId &&
-        relation.receiver.id === receiverId,
+      (relation) => relation.requester.id === requesterId && relation.receiver.id === receiverId,
     );
 
     if (sameDirectionRelation) {
@@ -62,15 +46,11 @@ export class FriendService {
     }
 
     const reverseRelation = existingRelations.find(
-      (relation) =>
-        relation.requester.id === receiverId &&
-        relation.receiver.id === requesterId,
+      (relation) => relation.requester.id === receiverId && relation.receiver.id === requesterId,
     );
 
     if (reverseRelation?.status === FriendStatus.PENDING) {
-      throw new ConflictException(
-        'Friend request from the target user already exists.',
-      );
+      throw new ConflictException('Friend request from the target user already exists.');
     }
 
     if (reverseRelation?.status === FriendStatus.ACCEPTED) {

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -1,0 +1,90 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
+import { UserService } from '../users/users.service';
+import { Friend, FriendStatus } from './entities/friend.entity';
+import { FriendRequestResponseDto } from './dto/friend-request-response.dto';
+import { FriendRepository } from './friends.repository';
+
+@Injectable()
+export class FriendService {
+  constructor(
+    private readonly friendRepository: FriendRepository,
+    private readonly userService: UserService,
+  ) {}
+
+  async createRequest(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<FriendRequestResponseDto> {
+    await this.validateReceiver(requesterId, receiverId);
+    await this.ensureRequestableRelation(requesterId, receiverId);
+
+    const friendRequest = await this.friendRepository.createOrRestoreRequest(
+      requesterId,
+      receiverId,
+    );
+
+    return this.toResponse(friendRequest);
+  }
+
+  private async validateReceiver(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<void> {
+    if (requesterId === receiverId) {
+      throw new BadRequestException('Cannot send friend request to yourself.');
+    }
+
+    await this.userService.findActiveUserOrFail(receiverId);
+  }
+
+  private async ensureRequestableRelation(
+    requesterId: number,
+    receiverId: number,
+  ): Promise<void> {
+    const existingRelations =
+      await this.friendRepository.findActiveRelationsBetweenUsers(
+        requesterId,
+        receiverId,
+      );
+
+    const sameDirectionRelation = existingRelations.find(
+      (relation) =>
+        relation.requester.id === requesterId &&
+        relation.receiver.id === receiverId,
+    );
+
+    if (sameDirectionRelation) {
+      throw new ConflictException('Friend request already exists.');
+    }
+
+    const reverseRelation = existingRelations.find(
+      (relation) =>
+        relation.requester.id === receiverId &&
+        relation.receiver.id === requesterId,
+    );
+
+    if (reverseRelation?.status === FriendStatus.PENDING) {
+      throw new ConflictException(
+        'Friend request from the target user already exists.',
+      );
+    }
+
+    if (reverseRelation?.status === FriendStatus.ACCEPTED) {
+      throw new ConflictException('Already friends.');
+    }
+  }
+
+  private toResponse(friend: Friend): FriendRequestResponseDto {
+    return {
+      id: friend.id,
+      requesterId: friend.requester.id,
+      receiverId: friend.receiver.id,
+      status: friend.status,
+      createdAt: friend.createdAt,
+    };
+  }
+}

--- a/src/users/dto/public-user-response.dto.ts
+++ b/src/users/dto/public-user-response.dto.ts
@@ -23,5 +23,5 @@ export class PublicUserResponseDto {
   mbti: string | null;
 
   @ApiProperty()
-  createdAt: Date;
+  createdAt: string;
 }

--- a/src/users/dto/update-me.dto.ts
+++ b/src/users/dto/update-me.dto.ts
@@ -1,13 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import {
-  IsDateString,
-  IsIn,
-  IsOptional,
-  IsString,
-  MaxLength,
-  MinLength,
-} from 'class-validator';
+import { IsDateString, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class UpdateMeDto {
   @ApiPropertyOptional({

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -9,12 +9,7 @@ import {
   ParseIntPipe,
   Patch,
 } from '@nestjs/common';
-import {
-  ApiNoContentResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
@@ -32,9 +27,7 @@ export class UserController {
   @Authenticated()
   @ApiOperation({ summary: '내 정보 조회' })
   @ApiOkResponse({ type: MeUserResponseDto })
-  async getMe(
-    @CurrentUser() currentUser: AuthenticatedUser,
-  ): Promise<MeUserResponseDto> {
+  async getMe(@CurrentUser() currentUser: AuthenticatedUser): Promise<MeUserResponseDto> {
     return this.userService.findMe(currentUser.userId);
   }
 

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -50,10 +50,7 @@ export class UserRepository {
     });
   }
 
-  async existsByNicknameExcludingUser(
-    nickname: string,
-    excludeUserId: number,
-  ): Promise<boolean> {
+  async existsByNicknameExcludingUser(nickname: string, excludeUserId: number): Promise<boolean> {
     const existingUser = await this.userRepository.findOne({
       select: {
         id: true,
@@ -91,10 +88,7 @@ export class UserRepository {
       .getOne();
   }
 
-  async updateRefreshTokenHash(
-    userId: number,
-    refreshTokenHash: string | null,
-  ): Promise<void> {
+  async updateRefreshTokenHash(userId: number, refreshTokenHash: string | null): Promise<void> {
     await this.userRepository.update(userId, { refreshTokenHash });
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,8 +1,4 @@
-import {
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { User } from './entities/user.entity';
 import { MeUserResponseDto } from './dto/me-user-response.dto';
 import { PublicUserResponseDto } from './dto/public-user-response.dto';
@@ -11,9 +7,7 @@ import { UserRepository } from './users.repository';
 
 @Injectable()
 export class UserService {
-  constructor(
-    private readonly userRepository: UserRepository,
-  ) {}
+  constructor(private readonly userRepository: UserRepository) {}
 
   async findAllUsers(): Promise<User[]> {
     return this.userRepository.findAll();
@@ -39,15 +33,9 @@ export class UserService {
     }
   }
 
-  async assertNicknameAvailable(
-    nickname: string,
-    excludeUserId?: number,
-  ): Promise<void> {
+  async assertNicknameAvailable(nickname: string, excludeUserId?: number): Promise<void> {
     const existingUser = excludeUserId
-      ? await this.userRepository.existsByNicknameExcludingUser(
-          nickname,
-          excludeUserId,
-        )
+      ? await this.userRepository.existsByNicknameExcludingUser(nickname, excludeUserId)
       : await this.userRepository.existsByNickname(nickname);
 
     if (existingUser) {
@@ -67,10 +55,7 @@ export class UserService {
     return this.userRepository.findByIdForAccessValidation(userId);
   }
 
-  async updateRefreshTokenHash(
-    userId: number,
-    refreshTokenHash: string | null,
-  ): Promise<void> {
+  async updateRefreshTokenHash(userId: number, refreshTokenHash: string | null): Promise<void> {
     await this.userRepository.updateRefreshTokenHash(userId, refreshTokenHash);
   }
 
@@ -110,10 +95,7 @@ export class UserService {
     return this.toMeResponse(user);
   }
 
-  async updateMe(
-    userId: number,
-    updateMeDto: UpdateMeDto,
-  ): Promise<MeUserResponseDto> {
+  async updateMe(userId: number, updateMeDto: UpdateMeDto): Promise<MeUserResponseDto> {
     const user = await this.findActiveUserOrFail(userId);
 
     if (updateMeDto.nickname) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -17,9 +17,6 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
   });
 });

--- a/test/auth-users.e2e-spec.ts
+++ b/test/auth-users.e2e-spec.ts
@@ -165,11 +165,9 @@ describe('Auth and Users (e2e)', () => {
     expect(response.body.refreshToken).toEqual(expect.any(String));
     expect(response.body.refreshToken).not.toBe(signupResponse.body.refreshToken);
 
-    const reusedRefreshResponse = await request(app.getHttpServer())
-      .post('/auth/refresh')
-      .send({
-        refreshToken: signupResponse.body.refreshToken,
-      });
+    const reusedRefreshResponse = await request(app.getHttpServer()).post('/auth/refresh').send({
+      refreshToken: signupResponse.body.refreshToken,
+    });
 
     expect(reusedRefreshResponse.status).toBe(401);
   });
@@ -249,7 +247,9 @@ describe('Auth and Users (e2e)', () => {
       mbti: 'ENFP',
     });
 
-    const response = await request(app.getHttpServer()).get(`/users/${signupResponse.body.user.id}`);
+    const response = await request(app.getHttpServer()).get(
+      `/users/${signupResponse.body.user.id}`,
+    );
 
     expect(response.status).toBe(200);
     expect(response.body.email).toBeUndefined();

--- a/test/friend-request.e2e-spec.ts
+++ b/test/friend-request.e2e-spec.ts
@@ -33,14 +33,16 @@ describe('Friend Request (e2e)', () => {
     birthDate?: string;
     schoolInfo?: string;
   }) {
-    return request(app.getHttpServer()).post('/auth/signup').send({
-      email: params.email,
-      password: 'password1234',
-      birthDate: params.birthDate ?? '1999-01-01',
-      gender: params.gender ?? 'MALE',
-      nickname: params.nickname,
-      schoolInfo: params.schoolInfo ?? 'Hongik University',
-    });
+    return request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        email: params.email,
+        password: 'password1234',
+        birthDate: params.birthDate ?? '1999-01-01',
+        gender: params.gender ?? 'MALE',
+        nickname: params.nickname,
+        schoolInfo: params.schoolInfo ?? 'Hongik University',
+      });
   }
 
   it('친구 신청 성공', async () => {
@@ -202,11 +204,9 @@ describe('Friend Request (e2e)', () => {
       nickname: 'unauthorized-receiver',
     });
 
-    const response = await request(app.getHttpServer())
-      .post('/friends/requests')
-      .send({
-        receiverId: receiver.body.user.id,
-      });
+    const response = await request(app.getHttpServer()).post('/friends/requests').send({
+      receiverId: receiver.body.user.id,
+    });
 
     expect(response.status).toBe(401);
   });

--- a/test/friend-request.e2e-spec.ts
+++ b/test/friend-request.e2e-spec.ts
@@ -1,0 +1,213 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Friend Request (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Friend).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  async function signupUser(params: {
+    email: string;
+    nickname: string;
+    gender?: 'MALE' | 'FEMALE';
+    birthDate?: string;
+    schoolInfo?: string;
+  }) {
+    return request(app.getHttpServer()).post('/auth/signup').send({
+      email: params.email,
+      password: 'password1234',
+      birthDate: params.birthDate ?? '1999-01-01',
+      gender: params.gender ?? 'MALE',
+      nickname: params.nickname,
+      schoolInfo: params.schoolInfo ?? 'Hongik University',
+    });
+  }
+
+  it('친구 신청 성공', async () => {
+    const requester = await signupUser({
+      email: 'requester@example.com',
+      nickname: 'requester',
+    });
+    const receiver = await signupUser({
+      email: 'receiver@example.com',
+      nickname: 'receiver',
+      gender: 'FEMALE',
+      birthDate: '1998-02-02',
+      schoolInfo: 'Yonsei University',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${requester.body.accessToken}`)
+      .send({
+        receiverId: receiver.body.user.id,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.requesterId).toBe(requester.body.user.id);
+    expect(response.body.receiverId).toBe(receiver.body.user.id);
+    expect(response.body.status).toBe(FriendStatus.PENDING);
+
+    const createdRequest = await dataSource.getRepository(Friend).findOne({
+      where: {
+        id: response.body.id,
+      },
+      relations: {
+        requester: true,
+        receiver: true,
+      },
+    });
+
+    expect(createdRequest).toBeDefined();
+    expect(createdRequest?.status).toBe(FriendStatus.PENDING);
+    expect(createdRequest?.requester.id).toBe(requester.body.user.id);
+    expect(createdRequest?.receiver.id).toBe(receiver.body.user.id);
+  });
+
+  it('자기 자신에게 친구 신청 시 400', async () => {
+    const user = await signupUser({
+      email: 'self@example.com',
+      nickname: 'self-user',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${user.body.accessToken}`)
+      .send({
+        receiverId: user.body.user.id,
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('존재하지 않는 사용자에게 신청 시 404', async () => {
+    const requester = await signupUser({
+      email: 'missing-target@example.com',
+      nickname: 'missing-target-requester',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${requester.body.accessToken}`)
+      .send({
+        receiverId: 999999,
+      });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('동일 방향 중복 신청 시 409', async () => {
+    const requester = await signupUser({
+      email: 'duplicate-requester@example.com',
+      nickname: 'duplicate-requester',
+    });
+    const receiver = await signupUser({
+      email: 'duplicate-receiver@example.com',
+      nickname: 'duplicate-receiver',
+    });
+
+    await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${requester.body.accessToken}`)
+      .send({
+        receiverId: receiver.body.user.id,
+      });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${requester.body.accessToken}`)
+      .send({
+        receiverId: receiver.body.user.id,
+      });
+
+    expect(response.status).toBe(409);
+  });
+
+  it('반대 방향 pending 관계가 있으면 409', async () => {
+    const firstUser = await signupUser({
+      email: 'reverse-first@example.com',
+      nickname: 'reverse-first',
+    });
+    const secondUser = await signupUser({
+      email: 'reverse-second@example.com',
+      nickname: 'reverse-second',
+    });
+
+    await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${secondUser.body.accessToken}`)
+      .send({
+        receiverId: firstUser.body.user.id,
+      });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${firstUser.body.accessToken}`)
+      .send({
+        receiverId: secondUser.body.user.id,
+      });
+
+    expect(response.status).toBe(409);
+  });
+
+  it('이미 친구인 경우 409', async () => {
+    const requester = await signupUser({
+      email: 'accepted-requester@example.com',
+      nickname: 'accepted-requester',
+    });
+    const receiver = await signupUser({
+      email: 'accepted-receiver@example.com',
+      nickname: 'accepted-receiver',
+    });
+
+    await dataSource.getRepository(Friend).save({
+      requester: { id: receiver.body.user.id } as User,
+      receiver: { id: requester.body.user.id } as User,
+      status: FriendStatus.ACCEPTED,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .set('Authorization', `Bearer ${requester.body.accessToken}`)
+      .send({
+        receiverId: receiver.body.user.id,
+      });
+
+    expect(response.status).toBe(409);
+  });
+
+  it('인증 없이 친구 신청 시 401', async () => {
+    const receiver = await signupUser({
+      email: 'unauthorized-receiver@example.com',
+      nickname: 'unauthorized-receiver',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/friends/requests')
+      .send({
+        receiverId: receiver.body.user.id,
+      });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -11,6 +11,7 @@ import { validationPipeOptions } from '../src/commons/validation/validation-pipe
 import { CommentLike } from '../src/comments/entities/comment-like.entity';
 import { Comment } from '../src/comments/entities/comment.entity';
 import { Friend } from '../src/friends/entities/friend.entity';
+import { FriendModule } from '../src/friends/friends.module';
 import { MealMenuReaction } from '../src/meal-menus/entities/meal-menu-reaction.entity';
 import { MealMenu } from '../src/meal-menus/entities/meal-menu.entity';
 import { PostCategory } from '../src/post-categories/entities/post-category.entity';
@@ -94,6 +95,7 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
       }),
       UserModule,
       AuthModule,
+      FriendModule,
     ],
   }).compile();
 

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -82,9 +82,7 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
             implementation: () => 'PostgreSQL 16.0',
           });
 
-          const dataSource = db.adapters.createTypeormDataSource(
-            options as DataSourceOptions,
-          );
+          const dataSource = db.adapters.createTypeormDataSource(options as DataSourceOptions);
 
           if (!dataSource.isInitialized) {
             await dataSource.initialize();


### PR DESCRIPTION
## 연관된 이슈

- #29

## 📝 작업 내용

- [x] `POST /friends/requests` API 구현
- [x] 친구 신청 엔티티/스키마 반영
- [x] `requester_user_id`, `addressee_user_id`, `status=PENDING` 저장 구조 반영
- [x] 자기 자신에게 친구 신청 불가 처리
- [x] 동일 사용자 대상 중복 친구 신청 제한
- [x] 이미 친구인 사용자에게 재신청 불가 처리
- [x] 친구 신청 성공 테스트 추가
- [x] 중복 신청 실패 테스트 추가
- [x] 자기 자신 신청 실패 테스트 추가
