### PR TITLE
MealMenu 학식 상세 조회 구현

### DIFF
--- a/src/meal-menus/dto/get-meal-menu-list-query.dto.ts
+++ b/src/meal-menus/dto/get-meal-menu-list-query.dto.ts
@@ -1,5 +1,4 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
 import { IsDateString, IsEnum, IsOptional } from 'class-validator';
 import { MealType } from '../entities/meal-menu.entity';
 
@@ -16,7 +15,6 @@ export class GetMealMenuListQueryDto {
     example: MealType.LUNCH,
   })
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toUpperCase() : value))
   @IsEnum(MealType)
   mealType?: MealType;
 }

--- a/src/meal-menus/dto/meal-menu-detail-response.dto.ts
+++ b/src/meal-menus/dto/meal-menu-detail-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MealType } from '../entities/meal-menu.entity';
+
+export class MealMenuDetailResponseDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  mealDate: string;
+
+  @ApiProperty({ enum: MealType })
+  mealType: MealType;
+
+  @ApiProperty()
+  menuName: string;
+
+  @ApiProperty({ nullable: true })
+  price: number | null;
+
+  @ApiProperty({ nullable: true })
+  calorie: number | null;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  dislikeCount: number;
+}

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
+import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
 import { MealMenusService } from './meal-menus.service';
 
@@ -14,5 +15,14 @@ export class MealMenusController {
   @ApiOkResponse({ type: MealMenuListResponseDto })
   async findMealMenus(@Query() query: GetMealMenuListQueryDto): Promise<MealMenuListResponseDto> {
     return this.mealMenusService.findMealMenus(query);
+  }
+
+  @Get(':mealMenuId')
+  @ApiOperation({ summary: '학식 상세 조회' })
+  @ApiOkResponse({ type: MealMenuDetailResponseDto })
+  async findMealMenuById(
+    @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
+  ): Promise<MealMenuDetailResponseDto> {
+    return this.mealMenusService.findMealMenuById(mealMenuId);
   }
 }

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -31,4 +31,11 @@ export class MealMenuRepository {
 
     return query.getMany();
   }
+
+  async findById(mealMenuId: number): Promise<MealMenu | null> {
+    return this.mealMenuRepository
+      .createQueryBuilder('mealMenu')
+      .where('mealMenu.id = :mealMenuId', { mealMenuId })
+      .getOne();
+  }
 }

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -25,7 +25,7 @@ export class MealMenuRepository {
       query.andWhere('mealMenu.meal_date = :mealDate', { mealDate: params.mealDate });
     }
 
-    if (params.mealType) {
+    if (params.mealType && params.mealType !== MealType.ALL) {
       query.andWhere('mealMenu.meal_type = :mealType', { mealType: params.mealType });
     }
 
@@ -33,9 +33,6 @@ export class MealMenuRepository {
   }
 
   async findById(mealMenuId: number): Promise<MealMenu | null> {
-    return this.mealMenuRepository
-      .createQueryBuilder('mealMenu')
-      .where('mealMenu.id = :mealMenuId', { mealMenuId })
-      .getOne();
+    return this.mealMenuRepository.findOneBy({ id: mealMenuId });
   }
 }

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
+import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
 import { MealMenu } from './entities/meal-menu.entity';
@@ -18,6 +19,16 @@ export class MealMenusService {
     };
   }
 
+  async findMealMenuById(mealMenuId: number): Promise<MealMenuDetailResponseDto> {
+    const mealMenu = await this.mealMenuRepository.findById(mealMenuId);
+
+    if (!mealMenu) {
+      throw new NotFoundException('Meal menu not found.');
+    }
+
+    return this.toDetailResponse(mealMenu);
+  }
+
   private toFindMealMenusParams(query: GetMealMenuListQueryDto): FindMealMenusParams {
     return {
       mealDate: query.mealDate,
@@ -34,6 +45,16 @@ export class MealMenusService {
   }
 
   private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {
+    return this.toBaseResponse(mealMenu);
+  }
+
+  private toDetailResponse(mealMenu: MealMenu): MealMenuDetailResponseDto {
+    return this.toBaseResponse(mealMenu);
+  }
+
+  private toBaseResponse(
+    mealMenu: MealMenu,
+  ): MealMenuListItemResponseDto | MealMenuDetailResponseDto {
     return {
       id: mealMenu.id,
       mealDate: this.formatMealDate(mealMenu.mealDate),

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -4,15 +4,17 @@ import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
 import { MealMenu } from './entities/meal-menu.entity';
-import { MealType } from './entities/meal-menu.entity';
-import { FindMealMenusParams, MealMenuRepository } from './meal-menus.repository';
+import { MealMenuRepository } from './meal-menus.repository';
 
 @Injectable()
 export class MealMenusService {
   constructor(private readonly mealMenuRepository: MealMenuRepository) {}
 
   async findMealMenus(query: GetMealMenuListQueryDto): Promise<MealMenuListResponseDto> {
-    const mealMenus = await this.mealMenuRepository.findMany(this.toFindMealMenusParams(query));
+    const mealMenus = await this.mealMenuRepository.findMany({
+      mealDate: query.mealDate,
+      mealType: query.mealType,
+    });
 
     return {
       items: mealMenus.map((mealMenu) => this.toListItem(mealMenu)),
@@ -29,32 +31,20 @@ export class MealMenusService {
     return this.toDetailResponse(mealMenu);
   }
 
-  private toFindMealMenusParams(query: GetMealMenuListQueryDto): FindMealMenusParams {
+  private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {
     return {
-      mealDate: query.mealDate,
-      mealType: this.normalizeMealType(query.mealType),
+      id: mealMenu.id,
+      mealDate: this.formatMealDate(mealMenu.mealDate),
+      mealType: mealMenu.mealType,
+      menuName: mealMenu.menuName,
+      price: mealMenu.price ?? null,
+      calorie: mealMenu.calorie ?? null,
+      likeCount: mealMenu.likeCount,
+      dislikeCount: mealMenu.dislikeCount,
     };
   }
 
-  private normalizeMealType(mealType?: MealType): MealType | undefined {
-    if (!mealType || mealType === MealType.ALL) {
-      return undefined;
-    }
-
-    return mealType;
-  }
-
-  private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {
-    return this.toBaseResponse(mealMenu);
-  }
-
   private toDetailResponse(mealMenu: MealMenu): MealMenuDetailResponseDto {
-    return this.toBaseResponse(mealMenu);
-  }
-
-  private toBaseResponse(
-    mealMenu: MealMenu,
-  ): MealMenuListItemResponseDto | MealMenuDetailResponseDto {
     return {
       id: mealMenu.id,
       mealDate: this.formatMealDate(mealMenu.mealDate),

--- a/test/meal-menu-detail.e2e-spec.ts
+++ b/test/meal-menu-detail.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { MealMenu, MealType } from '../src/meal-menus/entities/meal-menu.entity';
+import { createMealMenuTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Meal Menu Detail (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createMealMenuTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(MealMenu).execute();
+  });
+
+  async function createMealMenu(params: {
+    schoolInfo?: string;
+    mealDate: string;
+    mealType: MealType;
+    menuName: string;
+    price?: number | null;
+    calorie?: number | null;
+    likeCount?: number;
+    dislikeCount?: number;
+  }): Promise<MealMenu> {
+    return dataSource.getRepository(MealMenu).save({
+      schoolInfo: params.schoolInfo ?? 'Hongik University',
+      mealDate: params.mealDate,
+      mealType: params.mealType,
+      menuName: params.menuName,
+      price: params.price ?? null,
+      calorie: params.calorie ?? null,
+      likeCount: params.likeCount ?? 0,
+      dislikeCount: params.dislikeCount ?? 0,
+    });
+  }
+
+  it('학식 상세 조회 성공', async () => {
+    const mealMenu = await createMealMenu({
+      mealDate: '2026-03-30',
+      mealType: MealType.LUNCH,
+      menuName: '제육볶음',
+      price: 6000,
+      calorie: 750,
+      likeCount: 5,
+      dislikeCount: 2,
+    });
+
+    const response = await request(app.getHttpServer()).get(
+      `/meal-menus/${mealMenu.id}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      id: mealMenu.id,
+      mealDate: '2026-03-30',
+      mealType: MealType.LUNCH,
+      menuName: '제육볶음',
+      price: 6000,
+      calorie: 750,
+      likeCount: 5,
+      dislikeCount: 2,
+    });
+  });
+
+  it('존재하지 않는 학식 조회 시 404', async () => {
+    const response = await request(app.getHttpServer()).get('/meal-menus/999999');
+
+    expect(response.status).toBe(404);
+  });
+
+  it('soft delete 된 학식 조회 시 404', async () => {
+    const mealMenu = await createMealMenu({
+      mealDate: '2026-03-30',
+      mealType: MealType.DINNER,
+      menuName: '우동',
+    });
+
+    await dataSource.getRepository(MealMenu).softDelete(mealMenu.id);
+
+    const response = await request(app.getHttpServer()).get(
+      `/meal-menus/${mealMenu.id}`,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('인증 없이도 조회 가능', async () => {
+    const mealMenu = await createMealMenu({
+      mealDate: '2026-03-30',
+      mealType: MealType.BREAKFAST,
+      menuName: '토스트',
+    });
+
+    const response = await request(app.getHttpServer()).get(
+      `/meal-menus/${mealMenu.id}`,
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/test/meal-menu-detail.e2e-spec.ts
+++ b/test/meal-menu-detail.e2e-spec.ts
@@ -57,9 +57,7 @@ describe('Meal Menu Detail (e2e)', () => {
       dislikeCount: 2,
     });
 
-    const response = await request(app.getHttpServer()).get(
-      `/meal-menus/${mealMenu.id}`,
-    );
+    const response = await request(app.getHttpServer()).get(`/meal-menus/${mealMenu.id}`);
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -89,9 +87,7 @@ describe('Meal Menu Detail (e2e)', () => {
 
     await dataSource.getRepository(MealMenu).softDelete(mealMenu.id);
 
-    const response = await request(app.getHttpServer()).get(
-      `/meal-menus/${mealMenu.id}`,
-    );
+    const response = await request(app.getHttpServer()).get(`/meal-menus/${mealMenu.id}`);
 
     expect(response.status).toBe(404);
   });
@@ -103,9 +99,7 @@ describe('Meal Menu Detail (e2e)', () => {
       menuName: '토스트',
     });
 
-    const response = await request(app.getHttpServer()).get(
-      `/meal-menus/${mealMenu.id}`,
-    );
+    const response = await request(app.getHttpServer()).get(`/meal-menus/${mealMenu.id}`);
 
     expect(response.status).toBe(200);
   });


### PR DESCRIPTION
## 연관된 이슈

- #42

## 📝 작업 내용

- [x] `GET /meal-menus/{mealMenuId}` API 구현
- [x] `mealDate`, `mealType`, `menuName`, `price`, `calorie`, `likeCount`, `dislikeCount` 응답 반영
- [x] 존재하지 않는 학식 조회 실패 처리
- [x] soft delete 된 학식 조회 실패 처리
- [x] 학식 상세 조회 성공 테스트 추가
- [x] 존재하지 않는 학식 조회 실패 테스트 추가
