### PR TITLE
MealMenu 학식 좋아요 구현

### DIFF
--- a/src/meal-menus/dto/meal-menu-reaction-response.dto.ts
+++ b/src/meal-menus/dto/meal-menu-reaction-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ActionType } from '../entities/meal-menu-reaction.entity';
+
+export class MealMenuReactionResponseDto {
+  @ApiProperty({ enum: ActionType })
+  actionType: ActionType;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  dislikeCount: number;
+}

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -1,8 +1,12 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Authenticated } from '../auth/decorators/authenticated.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
 import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
+import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.dto';
 import { MealMenusService } from './meal-menus.service';
 
 @ApiTags('MealMenu')
@@ -24,5 +28,17 @@ export class MealMenusController {
     @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
   ): Promise<MealMenuDetailResponseDto> {
     return this.mealMenusService.findMealMenuById(mealMenuId);
+  }
+
+  @Post(':mealMenuId/like')
+  @HttpCode(HttpStatus.OK)
+  @Authenticated()
+  @ApiOperation({ summary: '학식 좋아요' })
+  @ApiOkResponse({ type: MealMenuReactionResponseDto })
+  async likeMealMenu(
+    @CurrentUser() currentUser: AuthenticatedUser,
+    @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
+  ): Promise<MealMenuReactionResponseDto> {
+    return this.mealMenusService.likeMealMenu(currentUser.userId, mealMenuId);
   }
 }

--- a/src/meal-menus/meal-menus.module.ts
+++ b/src/meal-menus/meal-menus.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenuReaction } from './entities/meal-menu-reaction.entity';
 import { MealMenusController } from './meal-menus.controller';
@@ -7,7 +8,7 @@ import { MealMenuRepository } from './meal-menus.repository';
 import { MealMenusService } from './meal-menus.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MealMenu, MealMenuReaction])],
+  imports: [TypeOrmModule.forFeature([MealMenu, MealMenuReaction]), AuthModule],
   controllers: [MealMenusController],
   providers: [MealMenuRepository, MealMenusService],
 })

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { MealMenu, MealType } from './entities/meal-menu.entity';
+import { ActionType, MealMenuReaction } from './entities/meal-menu-reaction.entity';
+import { User } from '../users/entities/user.entity';
 
 export interface FindMealMenusParams {
   mealDate?: string;
@@ -13,6 +15,9 @@ export class MealMenuRepository {
   constructor(
     @InjectRepository(MealMenu)
     private readonly mealMenuRepository: Repository<MealMenu>,
+    @InjectRepository(MealMenuReaction)
+    private readonly mealMenuReactionRepository: Repository<MealMenuReaction>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async findMany(params: FindMealMenusParams): Promise<MealMenu[]> {
@@ -34,5 +39,61 @@ export class MealMenuRepository {
 
   async findById(mealMenuId: number): Promise<MealMenu | null> {
     return this.mealMenuRepository.findOneBy({ id: mealMenuId });
+  }
+
+  async findReactionByUserAndMealMenu(
+    userId: number,
+    mealMenuId: number,
+  ): Promise<MealMenuReaction | null> {
+    return this.mealMenuReactionRepository.findOne({
+      where: {
+        user: { id: userId },
+        mealMenu: { id: mealMenuId },
+      },
+      relations: {
+        user: false,
+        mealMenu: false,
+      },
+    });
+  }
+
+  async applyLike(userId: number, mealMenuId: number): Promise<MealMenu> {
+    return this.dataSource.transaction(async (manager) => {
+      const mealMenuRepository = manager.getRepository(MealMenu);
+      const mealMenuReactionRepository = manager.getRepository(MealMenuReaction);
+
+      const mealMenu = await mealMenuRepository.findOneByOrFail({ id: mealMenuId });
+      const existingReaction = await mealMenuReactionRepository.findOne({
+        where: {
+          user: { id: userId },
+          mealMenu: { id: mealMenuId },
+        },
+      });
+
+      if (!existingReaction) {
+        await mealMenuReactionRepository.save(
+          mealMenuReactionRepository.create({
+            actionType: ActionType.LIKE,
+            user: { id: userId } as User,
+            mealMenu: { id: mealMenuId } as MealMenu,
+          }),
+        );
+
+        mealMenu.likeCount += 1;
+      } else if (existingReaction.actionType === ActionType.DISLIKE) {
+        existingReaction.actionType = ActionType.LIKE;
+        await mealMenuReactionRepository.save(existingReaction);
+
+        mealMenu.likeCount += 1;
+        mealMenu.dislikeCount = Math.max(0, mealMenu.dislikeCount - 1);
+      }
+
+      await mealMenuRepository.update(mealMenuId, {
+        likeCount: mealMenu.likeCount,
+        dislikeCount: mealMenu.dislikeCount,
+      });
+
+      return mealMenu;
+    });
   }
 }

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -3,6 +3,8 @@ import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
 import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
+import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.dto';
+import { ActionType } from './entities/meal-menu-reaction.entity';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenuRepository } from './meal-menus.repository';
 
@@ -29,6 +31,25 @@ export class MealMenusService {
     }
 
     return this.toDetailResponse(mealMenu);
+  }
+
+  async likeMealMenu(
+    userId: number,
+    mealMenuId: number,
+  ): Promise<MealMenuReactionResponseDto> {
+    const mealMenu = await this.mealMenuRepository.findById(mealMenuId);
+
+    if (!mealMenu) {
+      throw new NotFoundException('Meal menu not found.');
+    }
+
+    const updatedMealMenu = await this.mealMenuRepository.applyLike(userId, mealMenuId);
+
+    return {
+      actionType: ActionType.LIKE,
+      likeCount: updatedMealMenu.likeCount,
+      dislikeCount: updatedMealMenu.dislikeCount,
+    };
   }
 
   private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {

--- a/test/meal-menu-like.e2e-spec.ts
+++ b/test/meal-menu-like.e2e-spec.ts
@@ -1,0 +1,191 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { MealMenu, MealType } from '../src/meal-menus/entities/meal-menu.entity';
+import { ActionType, MealMenuReaction } from '../src/meal-menus/entities/meal-menu-reaction.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createMealMenuAuthTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Meal Menu Like (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createMealMenuAuthTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(MealMenuReaction).execute();
+    await dataSource.createQueryBuilder().delete().from(MealMenu).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  async function signupAndGetAccessToken(email: string, nickname: string): Promise<string> {
+    const response = await request(app.getHttpServer()).post('/auth/signup').send({
+      email,
+      password: 'password1234',
+      birthDate: '1999-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: 'Hongik University',
+    });
+
+    return response.body.accessToken as string;
+  }
+
+  async function createMealMenu(params?: {
+    mealDate?: string;
+    mealType?: MealType;
+    menuName?: string;
+    likeCount?: number;
+    dislikeCount?: number;
+  }): Promise<MealMenu> {
+    return dataSource.getRepository(MealMenu).save({
+      schoolInfo: 'Hongik University',
+      mealDate: params?.mealDate ?? '2026-03-31',
+      mealType: params?.mealType ?? MealType.LUNCH,
+      menuName: params?.menuName ?? '돈까스',
+      price: 5500,
+      calorie: 800,
+      likeCount: params?.likeCount ?? 0,
+      dislikeCount: params?.dislikeCount ?? 0,
+    });
+  }
+
+  it('학식 좋아요 성공', async () => {
+    const accessToken = await signupAndGetAccessToken('like@example.com', 'like-user');
+    const mealMenu = await createMealMenu();
+
+    const response = await request(app.getHttpServer())
+      .post(`/meal-menus/${mealMenu.id}/like`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      actionType: ActionType.LIKE,
+      likeCount: 1,
+      dislikeCount: 0,
+    });
+
+    const savedReaction = await dataSource.getRepository(MealMenuReaction).findOne({
+      where: {
+        mealMenu: { id: mealMenu.id },
+      },
+      relations: {
+        user: true,
+        mealMenu: true,
+      },
+    });
+
+    expect(savedReaction?.actionType).toBe(ActionType.LIKE);
+  });
+
+  it('인증 없이 요청 시 401', async () => {
+    const mealMenu = await createMealMenu();
+
+    const response = await request(app.getHttpServer()).post(`/meal-menus/${mealMenu.id}/like`);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('존재하지 않는 학식 좋아요 시 404', async () => {
+    const accessToken = await signupAndGetAccessToken('missing@example.com', 'missing-user');
+
+    const response = await request(app.getHttpServer())
+      .post('/meal-menus/999999/like')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(404);
+  });
+
+  it('기존 DISLIKE에서 좋아요 호출 시 LIKE로 전환되고 카운트가 교정됨', async () => {
+    const accessToken = await signupAndGetAccessToken('switch@example.com', 'switch-user');
+    const mealMenu = await createMealMenu({ likeCount: 0, dislikeCount: 1 });
+    const user = await dataSource.getRepository(User).findOneByOrFail({ email: 'switch@example.com' });
+
+    await dataSource.getRepository(MealMenuReaction).save({
+      actionType: ActionType.DISLIKE,
+      user,
+      mealMenu,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post(`/meal-menus/${mealMenu.id}/like`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      actionType: ActionType.LIKE,
+      likeCount: 1,
+      dislikeCount: 0,
+    });
+
+    const savedReaction = await dataSource.getRepository(MealMenuReaction).findOneByOrFail({
+      user: { id: user.id },
+      mealMenu: { id: mealMenu.id },
+    });
+
+    expect(savedReaction.actionType).toBe(ActionType.LIKE);
+  });
+
+  it('이미 LIKE인 상태에서 다시 호출 시 200 멱등 성공', async () => {
+    const accessToken = await signupAndGetAccessToken('idempotent@example.com', 'idempotent-user');
+    const mealMenu = await createMealMenu({ likeCount: 1, dislikeCount: 0 });
+    const user = await dataSource
+      .getRepository(User)
+      .findOneByOrFail({ email: 'idempotent@example.com' });
+
+    await dataSource.getRepository(MealMenuReaction).save({
+      actionType: ActionType.LIKE,
+      user,
+      mealMenu,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post(`/meal-menus/${mealMenu.id}/like`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      actionType: ActionType.LIKE,
+      likeCount: 1,
+      dislikeCount: 0,
+    });
+
+    const reactions = await dataSource.getRepository(MealMenuReaction).find({
+      where: {
+        user: { id: user.id },
+        mealMenu: { id: mealMenu.id },
+      },
+    });
+
+    expect(reactions).toHaveLength(1);
+  });
+
+  it('목록/상세 응답의 카운트가 변경 후 값과 일치함', async () => {
+    const accessToken = await signupAndGetAccessToken('counts@example.com', 'counts-user');
+    const mealMenu = await createMealMenu();
+
+    await request(app.getHttpServer())
+      .post(`/meal-menus/${mealMenu.id}/like`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    const listResponse = await request(app.getHttpServer()).get('/meal-menus');
+    const detailResponse = await request(app.getHttpServer()).get(`/meal-menus/${mealMenu.id}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(detailResponse.status).toBe(200);
+    expect(listResponse.body.items[0].likeCount).toBe(1);
+    expect(listResponse.body.items[0].dislikeCount).toBe(0);
+    expect(detailResponse.body.likeCount).toBe(1);
+    expect(detailResponse.body.dislikeCount).toBe(0);
+  });
+});

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -150,3 +150,58 @@ export async function createMealMenuTestApp(): Promise<INestApplication> {
 
   return app;
 }
+
+export async function createMealMenuAuthTestApp(): Promise<INestApplication> {
+  process.env.JWT_ACCESS_SECRET = 'test-access-secret';
+  process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+  process.env.JWT_ACCESS_EXPIRES_IN = '15m';
+  process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot({
+        isGlobal: true,
+        ignoreEnvFile: true,
+      }),
+      TypeOrmModule.forRootAsync({
+        useFactory: () => ({
+          type: 'postgres',
+          synchronize: true,
+          logging: false,
+          entities: TEST_ENTITIES,
+        }),
+        dataSourceFactory: async (options) => {
+          const db = newDb({
+            autoCreateForeignKeyIndices: true,
+          });
+
+          db.public.registerFunction({
+            name: 'current_database',
+            implementation: () => 'lunchmate_test',
+          });
+          db.public.registerFunction({
+            name: 'version',
+            implementation: () => 'PostgreSQL 16.0',
+          });
+
+          const dataSource = db.adapters.createTypeormDataSource(options as DataSourceOptions);
+
+          if (!dataSource.isInitialized) {
+            await dataSource.initialize();
+          }
+
+          return dataSource as DataSource;
+        },
+      }),
+      UserModule,
+      AuthModule,
+      MealMenuModule,
+    ],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
+  await app.init();
+
+  return app;
+}


### PR DESCRIPTION
## 연관된 이슈

- #43

## 📝 작업 내용

- [x] `POST /meal-menus/{mealMenuId}/like` API 구현
- [x] `menu_reactions.action_type = LIKE` 저장 처리
- [x] 같은 사용자의 기존 반응이 있으면 중복 처리 정책 반영
- [x] `likeCount`, `dislikeCount` 응답 반영
- [x] 존재하지 않는 학식 좋아요 실패 처리
- [x] 인증 없는 요청 실패 테스트 추가
- [x] 학식 좋아요 성공 테스트 추가
- [x] 중복 또는 반응 전환 테스트 추가