### PR TITLE
MealMenu 학식 랭킹 조회 구현

### DIFF
--- a/src/meal-menus/dto/get-meal-menu-ranking-query.dto.ts
+++ b/src/meal-menus/dto/get-meal-menu-ranking-query.dto.ts
@@ -1,0 +1,28 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { ActionType } from '../entities/meal-menu-reaction.entity';
+import { MealType } from '../entities/meal-menu.entity';
+
+export class GetMealMenuRankingQueryDto {
+  @ApiPropertyOptional({
+    example: '2026-03-31',
+  })
+  @IsOptional()
+  @IsDateString()
+  mealDate?: string;
+
+  @ApiPropertyOptional({
+    enum: MealType,
+    example: MealType.LUNCH,
+  })
+  @IsOptional()
+  @IsEnum(MealType)
+  mealType?: MealType;
+
+  @ApiPropertyOptional({
+    enum: ActionType,
+    example: ActionType.LIKE,
+  })
+  @IsEnum(ActionType)
+  actionType: ActionType;
+}

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -4,6 +4,7 @@ import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
+import { GetMealMenuRankingQueryDto } from './dto/get-meal-menu-ranking-query.dto';
 import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
 import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.dto';
@@ -19,6 +20,15 @@ export class MealMenusController {
   @ApiOkResponse({ type: MealMenuListResponseDto })
   async findMealMenus(@Query() query: GetMealMenuListQueryDto): Promise<MealMenuListResponseDto> {
     return this.mealMenusService.findMealMenus(query);
+  }
+
+  @Get('rankings')
+  @ApiOperation({ summary: '학식 랭킹 조회' })
+  @ApiOkResponse({ type: MealMenuListResponseDto })
+  async findMealMenuRankings(
+    @Query() query: GetMealMenuRankingQueryDto,
+  ): Promise<MealMenuListResponseDto> {
+    return this.mealMenusService.findMealMenuRankings(query);
   }
 
   @Get(':mealMenuId')

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -10,6 +10,12 @@ export interface FindMealMenusParams {
   mealType?: MealType;
 }
 
+export interface FindMealMenuRankingsParams {
+  mealDate?: string;
+  mealType?: MealType;
+  actionType: ActionType;
+}
+
 @Injectable()
 export class MealMenuRepository {
   constructor(
@@ -39,6 +45,28 @@ export class MealMenuRepository {
 
   async findById(mealMenuId: number): Promise<MealMenu | null> {
     return this.mealMenuRepository.findOneBy({ id: mealMenuId });
+  }
+
+  async findRankings(params: FindMealMenuRankingsParams): Promise<MealMenu[]> {
+    const query = this.mealMenuRepository.createQueryBuilder('mealMenu');
+
+    if (params.mealDate) {
+      query.andWhere('mealMenu.meal_date = :mealDate', { mealDate: params.mealDate });
+    }
+
+    if (params.mealType && params.mealType !== MealType.ALL) {
+      query.andWhere('mealMenu.meal_type = :mealType', { mealType: params.mealType });
+    }
+
+    if (params.actionType === ActionType.LIKE) {
+      query.orderBy('mealMenu.like_count', 'DESC');
+    } else {
+      query.orderBy('mealMenu.dislike_count', 'DESC');
+    }
+
+    query.addOrderBy('mealMenu.id', 'DESC');
+
+    return query.getMany();
   }
 
   async findReactionByUserAndMealMenu(

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
+import { GetMealMenuRankingQueryDto } from './dto/get-meal-menu-ranking-query.dto';
 import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
 import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
@@ -16,6 +17,18 @@ export class MealMenusService {
     const mealMenus = await this.mealMenuRepository.findMany({
       mealDate: query.mealDate,
       mealType: query.mealType,
+    });
+
+    return {
+      items: mealMenus.map((mealMenu) => this.toListItem(mealMenu)),
+    };
+  }
+
+  async findMealMenuRankings(query: GetMealMenuRankingQueryDto): Promise<MealMenuListResponseDto> {
+    const mealMenus = await this.mealMenuRepository.findRankings({
+      mealDate: query.mealDate,
+      mealType: query.mealType,
+      actionType: query.actionType,
     });
 
     return {

--- a/test/meal-menu-ranking.e2e-spec.ts
+++ b/test/meal-menu-ranking.e2e-spec.ts
@@ -1,0 +1,184 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { MealMenu, MealType } from '../src/meal-menus/entities/meal-menu.entity';
+import { ActionType } from '../src/meal-menus/entities/meal-menu-reaction.entity';
+import { createMealMenuTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Meal Menu Ranking (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createMealMenuTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(MealMenu).execute();
+  });
+
+  async function createMealMenu(params: {
+    mealDate: string;
+    mealType: MealType;
+    menuName: string;
+    price?: number | null;
+    calorie?: number | null;
+    likeCount?: number;
+    dislikeCount?: number;
+  }): Promise<MealMenu> {
+    return dataSource.getRepository(MealMenu).save({
+      schoolInfo: 'Hongik University',
+      mealDate: params.mealDate,
+      mealType: params.mealType,
+      menuName: params.menuName,
+      price: params.price ?? null,
+      calorie: params.calorie ?? null,
+      likeCount: params.likeCount ?? 0,
+      dislikeCount: params.dislikeCount ?? 0,
+    });
+  }
+
+  it('actionType=LIKE 랭킹 조회 성공', async () => {
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'A',
+      likeCount: 1,
+      dislikeCount: 0,
+    });
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'B',
+      likeCount: 5,
+      dislikeCount: 1,
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.LIKE });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0].menuName).toBe('B');
+    expect(response.body.items[0].likeCount).toBe(5);
+  });
+
+  it('actionType=DISLIKE 랭킹 조회 성공', async () => {
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'A',
+      likeCount: 1,
+      dislikeCount: 2,
+    });
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'B',
+      likeCount: 5,
+      dislikeCount: 7,
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.DISLIKE });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0].menuName).toBe('B');
+    expect(response.body.items[0].dislikeCount).toBe(7);
+  });
+
+  it('mealDate 필터 적용', async () => {
+    await createMealMenu({
+      mealDate: '2026-03-30',
+      mealType: MealType.LUNCH,
+      menuName: 'A',
+      likeCount: 3,
+    });
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'B',
+      likeCount: 5,
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.LIKE, mealDate: '2026-03-31' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].mealDate).toBe('2026-03-31');
+  });
+
+  it('mealType 필터 적용', async () => {
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.BREAKFAST,
+      menuName: 'A',
+      dislikeCount: 2,
+    });
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.DINNER,
+      menuName: 'B',
+      dislikeCount: 5,
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.DISLIKE, mealType: MealType.DINNER });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].mealType).toBe(MealType.DINNER);
+  });
+
+  it('결과 없을 때 빈 배열 반환', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.LIKE });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toEqual([]);
+  });
+
+  it('인증 없이도 조회 가능', async () => {
+    await createMealMenu({
+      mealDate: '2026-03-31',
+      mealType: MealType.LUNCH,
+      menuName: 'A',
+      likeCount: 1,
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: ActionType.LIKE });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('actionType 누락 시 400', async () => {
+    const response = await request(app.getHttpServer()).get('/meal-menus/rankings');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('잘못된 actionType 값 시 400', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/meal-menus/rankings')
+      .query({ actionType: 'INVALID' });
+
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 연관된 이슈

- #45

## 📝 작업 내용

- [x] `GET /meal-menus/rankings` API 구현
- [x] `mealDate`, `mealType`, `actionType` 기준 정렬/필터 처리
- [x] 좋아요 기준 랭킹 조회 처리
- [x] 싫어요 기준 랭킹 조회 처리
- [x] 랭킹 응답 구조 반영
- [x] 랭킹 조회 성공 테스트 추가
- [x] 정렬 기준별 조회 테스트 추가
- [x] 결과 없을 때 빈 배열 반환 테스트 추가
