### PR TITLE
User Me 응답 DTO 네이밍 정리

### DIFF
--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { MeUserResponseDto } from '../../users/dto/me-user-response.dto';
+import { CurrentUserResponseDto } from '../../users/dto/current-user-response.dto';
 
 export class AuthTokensResponseDto {
   @ApiProperty()
@@ -10,6 +10,6 @@ export class AuthTokensResponseDto {
 }
 
 export class AuthResponseDto extends AuthTokensResponseDto {
-  @ApiProperty({ type: MeUserResponseDto })
-  user: MeUserResponseDto;
+  @ApiProperty({ type: CurrentUserResponseDto })
+  user: CurrentUserResponseDto;
 }

--- a/src/users/dto/current-user-response.dto.ts
+++ b/src/users/dto/current-user-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PublicUserResponseDto } from './public-user-response.dto';
 
-export class MeUserResponseDto extends PublicUserResponseDto {
+export class CurrentUserResponseDto extends PublicUserResponseDto {
   @ApiProperty()
   email: string;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -13,7 +13,7 @@ import { ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nes
 import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
-import { MeUserResponseDto } from './dto/me-user-response.dto';
+import { CurrentUserResponseDto } from './dto/current-user-response.dto';
 import { PublicUserResponseDto } from './dto/public-user-response.dto';
 import { UpdateMeDto } from './dto/update-me.dto';
 import { UserService } from './users.service';
@@ -26,19 +26,21 @@ export class UserController {
   @Get('me')
   @Authenticated()
   @ApiOperation({ summary: '내 정보 조회' })
-  @ApiOkResponse({ type: MeUserResponseDto })
-  async getMe(@CurrentUser() currentUser: AuthenticatedUser): Promise<MeUserResponseDto> {
+  @ApiOkResponse({ type: CurrentUserResponseDto })
+  async getMe(
+    @CurrentUser() currentUser: AuthenticatedUser,
+  ): Promise<CurrentUserResponseDto> {
     return this.userService.findMe(currentUser.userId);
   }
 
   @Patch('me')
   @Authenticated()
   @ApiOperation({ summary: '내 프로필 수정' })
-  @ApiOkResponse({ type: MeUserResponseDto })
+  @ApiOkResponse({ type: CurrentUserResponseDto })
   async updateMe(
     @CurrentUser() currentUser: AuthenticatedUser,
     @Body() updateMeDto: UpdateMeDto,
-  ): Promise<MeUserResponseDto> {
+  ): Promise<CurrentUserResponseDto> {
     return this.userService.updateMe(currentUser.userId, updateMeDto);
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { User } from './entities/user.entity';
-import { MeUserResponseDto } from './dto/me-user-response.dto';
+import { CurrentUserResponseDto } from './dto/current-user-response.dto';
 import { PublicUserResponseDto } from './dto/public-user-response.dto';
 import { UpdateMeDto } from './dto/update-me.dto';
 import { UserRepository } from './users.repository';
@@ -90,12 +90,12 @@ export class UserService {
     return this.toPublicResponse(user);
   }
 
-  async findMe(userId: number): Promise<MeUserResponseDto> {
+  async findMe(userId: number): Promise<CurrentUserResponseDto> {
     const user = await this.findActiveUserOrFail(userId);
     return this.toMeResponse(user);
   }
 
-  async updateMe(userId: number, updateMeDto: UpdateMeDto): Promise<MeUserResponseDto> {
+  async updateMe(userId: number, updateMeDto: UpdateMeDto): Promise<CurrentUserResponseDto> {
     const user = await this.findActiveUserOrFail(userId);
 
     if (updateMeDto.nickname) {
@@ -132,7 +132,7 @@ export class UserService {
     };
   }
 
-  toMeResponse(user: User): MeUserResponseDto {
+  toMeResponse(user: User): CurrentUserResponseDto {
     return {
       ...this.toPublicResponse(user),
       email: user.email,


### PR DESCRIPTION
## 연관된 이슈

- #53

## 📝 작업 내용

- [x] `/users/me` 응답 DTO 네이밍 재검토
- [x] 현재 DTO명과 Swagger 응답 타입 정리
- [x] 관련 서비스/컨트롤러 반환 타입 정렬
- [x] 네이밍 변경 시 테스트/문서 반영
