### PR TITLE
User 응답 DTO 분리 기준 정리

### DIFF
--- a/src/users/dto/current-user-response.dto.ts
+++ b/src/users/dto/current-user-response.dto.ts
@@ -1,7 +1,30 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { PublicUserResponseDto } from './public-user-response.dto';
 
-export class CurrentUserResponseDto extends PublicUserResponseDto {
+export class CurrentUserResponseDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  nickname: string;
+
+  @ApiProperty()
+  birthDate: string;
+
+  @ApiProperty({ enum: ['MALE', 'FEMALE'] })
+  gender: 'MALE' | 'FEMALE';
+
+  @ApiProperty()
+  schoolInfo: string;
+
+  @ApiProperty({ nullable: true })
+  introduce: string | null;
+
+  @ApiProperty({ nullable: true })
+  mbti: string | null;
+
+  @ApiProperty()
+  createdAt: string;
+
   @ApiProperty()
   email: string;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -134,7 +134,14 @@ export class UserService {
 
   toMeResponse(user: User): CurrentUserResponseDto {
     return {
-      ...this.toPublicResponse(user),
+      id: user.id,
+      nickname: user.nickname,
+      birthDate: user.birthDate,
+      gender: user.gender,
+      schoolInfo: user.schoolInfo,
+      introduce: user.introduce,
+      mbti: user.mbti,
+      createdAt: user.createdAt,
       email: user.email,
     };
   }


### PR DESCRIPTION
## 연관된 이슈

- #54

## 📝 작업 내용

- [x] `PublicUserResponseDto`, `MeUserResponseDto` 책임 분리 재정의
- [x] API별 독립 DTO 필요 여부 검토 및 적용
- [x] 상속/공유 필드 구조 정리
- [x] Swagger 응답 타입 정리
