### PR TITLE
방 목록 조회, 상세 조회 API 구현

### DIFF
--- a/src/rooms/constants/room.constant.ts
+++ b/src/rooms/constants/room.constant.ts
@@ -6,3 +6,8 @@ export const ROOM_CONSTANTS = {
   MAX_AGE: 100,
   PLACE_MAX_LENGTH: 100,
 } as const;
+
+export const PAGINATION_CONSTANTS = {
+  DEFAULT_LIMIT: 20,
+  MAX_LIMIT: 200,
+};

--- a/src/rooms/dto/create-room.dto.ts
+++ b/src/rooms/dto/create-room.dto.ts
@@ -31,7 +31,6 @@ export class CreateRoomDto extends PickType(Room, [
   @MaxLength(ROOM_CONSTANTS.TITLE_MAX_LENGTH)
   title: string;
 
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @ApiProperty({ enum: RoomType, example: RoomType.MALE })
   @IsEnum(RoomType)
   @IsNotEmpty()

--- a/src/rooms/dto/find-rooms-query.dto.ts
+++ b/src/rooms/dto/find-rooms-query.dto.ts
@@ -1,0 +1,67 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsDateString, IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { RoomStatus, RoomType } from '../entities/room.entity';
+import { PAGINATION_CONSTANTS, ROOM_CONSTANTS } from '../constants/room.constant';
+
+export class FindRoomsQueryDto {
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  cursor?: number;
+
+  @ApiPropertyOptional({
+    minimum: 1,
+    maximum: PAGINATION_CONSTANTS.MAX_LIMIT,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
+  limit?: number;
+
+  @ApiPropertyOptional({ enum: RoomType })
+  @IsOptional()
+  @IsEnum(RoomType)
+  roomType?: RoomType;
+
+  @ApiPropertyOptional({ enum: RoomStatus })
+  @IsOptional()
+  @IsEnum(RoomStatus)
+  status?: RoomStatus;
+
+  @ApiPropertyOptional({ minimum: ROOM_CONSTANTS.MIN_AGE, maximum: ROOM_CONSTANTS.MAX_AGE })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(ROOM_CONSTANTS.MIN_AGE)
+  @Max(ROOM_CONSTANTS.MAX_AGE)
+  minAge?: number;
+
+  @ApiPropertyOptional({ minimum: ROOM_CONSTANTS.MIN_AGE, maximum: ROOM_CONSTANTS.MAX_AGE })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(ROOM_CONSTANTS.MIN_AGE)
+  @Max(ROOM_CONSTANTS.MAX_AGE)
+  maxAge?: number;
+
+  @ApiPropertyOptional({
+    description: '조회 시작 식사 시간(이상)',
+    example: '2026-03-31 12:00:00.00',
+  })
+  @IsOptional()
+  @IsDateString()
+  lunchAtFrom?: string;
+
+  @ApiPropertyOptional({
+    description: '조회 종료 식사 시간(이하)',
+    example: '2026-03-31 14:00:00',
+  })
+  @IsOptional()
+  @IsDateString()
+  lunchAtTo?: string;
+}

--- a/src/rooms/dto/room-response.dto.ts
+++ b/src/rooms/dto/room-response.dto.ts
@@ -15,7 +15,7 @@ export class ResponseRoomMemberDto {
   schoolInfo: string;
 }
 
-export class ResponseRoomDetailDto {
+export class ResponseRoomItemDto {
   @ApiProperty()
   id: number;
 
@@ -50,11 +50,29 @@ export class ResponseRoomDetailDto {
   lunchAt: string;
 
   @ApiProperty()
-  createdAt: string;
+  hostUserId: number;
+}
+
+export class ResponseRoomListDto {
+  @ApiProperty({ type: () => [ResponseRoomItemDto] })
+  items: ResponseRoomItemDto[];
+
+  @ApiProperty({ nullable: true })
+  nextCursor: number | null;
 
   @ApiProperty()
-  hostUserId: number;
+  hasNext: boolean;
+}
+
+export class ResponseRoomDetailDto extends ResponseRoomItemDto {
+  @ApiProperty()
+  createdAt: string;
 
   @ApiProperty({ type: () => [ResponseRoomMemberDto] })
   roomMembers: ResponseRoomMemberDto[];
+}
+
+export class ResponseOpenRoomsCountDto {
+  @ApiProperty()
+  openRoomsCount: number;
 }

--- a/src/rooms/mappers/room.mapper.ts
+++ b/src/rooms/mappers/room.mapper.ts
@@ -1,8 +1,12 @@
-import { ResponseRoomDetailDto } from '../dto/room-response.dto';
+import {
+  ResponseRoomDetailDto,
+  ResponseRoomListDto,
+  ResponseRoomItemDto,
+} from '../dto/room-response.dto';
 import { Room } from '../entities/room.entity';
 
 export class RoomMapper {
-  static toDetailDto(room: Room): ResponseRoomDetailDto {
+  static toItemDto(room: Room): ResponseRoomItemDto {
     return {
       id: room.id,
       title: room.title,
@@ -15,8 +19,26 @@ export class RoomMapper {
       maxAge: room.maxAge,
       place: room.place,
       lunchAt: room.lunchAt,
-      createdAt: room.createdAt,
       hostUserId: room.hostUser.id,
+    };
+  }
+
+  static toListDto(
+    rooms: Room[],
+    nextCursor: number | null,
+    hasNext: boolean,
+  ): ResponseRoomListDto {
+    return {
+      items: rooms.map((room) => this.toItemDto(room)),
+      nextCursor,
+      hasNext,
+    };
+  }
+
+  static toDetailDto(room: Room): ResponseRoomDetailDto {
+    return {
+      ...this.toItemDto(room),
+      createdAt: room.createdAt,
       roomMembers: room.roomMembers.map((member) => ({
         id: member.user.id,
         nickname: member.user.nickname,

--- a/src/rooms/room.repository.spec.ts
+++ b/src/rooms/room.repository.spec.ts
@@ -1,0 +1,64 @@
+import { Between, LessThan, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
+import { RoomRepository } from './room.repository';
+import { Room, RoomStatus, RoomType } from './entities/room.entity';
+import { RoomMember } from './entities/room-member.entity';
+import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
+
+describe('RoomRepository', () => {
+  let roomRepository: RoomRepository;
+
+  beforeEach(() => {
+    roomRepository = new RoomRepository({} as Repository<Room>, {} as Repository<RoomMember>);
+  });
+
+  describe('findRoomFilter', () => {
+    it('roomType, status, age, cursor 조건을 포함한 필터를 생성', () => {
+      const query: FindRoomsQueryDto = {
+        roomType: RoomType.MALE,
+        status: RoomStatus.OPEN,
+        minAge: 20,
+        maxAge: 24,
+        cursor: 10,
+      };
+
+      const result = roomRepository.findRoomFilter(query);
+
+      expect(result.roomType).toBe(RoomType.MALE);
+      expect(result.status).toBe(RoomStatus.OPEN);
+      expect(result.minAge).toEqual(MoreThanOrEqual(20));
+      expect(result.maxAge).toEqual(LessThanOrEqual(24));
+      expect(result.id).toEqual(LessThan(10));
+    });
+
+    it('lunchAtFrom과 lunchAtTo가 모두 있으면 Between 조건을 생성', () => {
+      const query: FindRoomsQueryDto = {
+        lunchAtFrom: '2026-03-31 12:00:00',
+        lunchAtTo: '2026-03-31 14:00:00',
+      };
+
+      const result = roomRepository.findRoomFilter(query);
+
+      expect(result.lunchAt).toEqual(Between('2026-03-31 12:00:00', '2026-03-31 14:00:00'));
+    });
+
+    it('lunchAtFrom만 있으면 MoreThanOrEqual 조건을 생성', () => {
+      const query: FindRoomsQueryDto = {
+        lunchAtFrom: '2026-03-31 12:00:00',
+      };
+
+      const result = roomRepository.findRoomFilter(query);
+
+      expect(result.lunchAt).toEqual(MoreThanOrEqual('2026-03-31 12:00:00'));
+    });
+
+    it('lunchAtTo만 있으면 LessThanOrEqual 조건을 생성', () => {
+      const query: FindRoomsQueryDto = {
+        lunchAtTo: '2026-03-31 14:00:00',
+      };
+
+      const result = roomRepository.findRoomFilter(query);
+
+      expect(result.lunchAt).toEqual(LessThanOrEqual('2026-03-31 14:00:00'));
+    });
+  });
+});

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -1,9 +1,19 @@
 import { CreateRoomDto } from './dto/create-room.dto';
+import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { RoomMember } from './entities/room-member.entity';
 import { Room, RoomStatus } from './entities/room.entity';
-import { EntityManager, Repository } from 'typeorm';
+import {
+  Between,
+  EntityManager,
+  FindOptionsWhere,
+  LessThan,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Repository,
+} from 'typeorm';
+import { PAGINATION_CONSTANTS } from './constants/room.constant';
 
 @Injectable()
 export class RoomRepository {
@@ -56,6 +66,52 @@ export class RoomRepository {
         roomMembers: {
           user: true,
         },
+      },
+    });
+  }
+
+  async findRooms(query: FindRoomsQueryDto): Promise<Room[]> {
+    const where: FindOptionsWhere<Room> = this.findRoomFilter(query);
+    const limit = query.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
+
+    return await this.roomRepository.find({
+      where,
+      relations: {
+        hostUser: true,
+      },
+      order: {
+        id: 'DESC',
+      },
+      take: limit + 1,
+    });
+  }
+
+  findRoomFilter(query: FindRoomsQueryDto): FindOptionsWhere<Room> {
+    const where: FindOptionsWhere<Room> = {};
+
+    if (query.roomType) where.roomType = query.roomType;
+    if (query.status) where.status = query.status;
+
+    if (query.maxAge !== undefined) where.maxAge = LessThanOrEqual(query.maxAge);
+    if (query.minAge !== undefined) where.minAge = MoreThanOrEqual(query.minAge);
+
+    if (query.lunchAtFrom !== undefined && query.lunchAtTo !== undefined) {
+      where.lunchAt = Between(query.lunchAtFrom, query.lunchAtTo);
+    } else if (query.lunchAtFrom !== undefined) {
+      where.lunchAt = MoreThanOrEqual(query.lunchAtFrom);
+    } else if (query.lunchAtTo !== undefined) {
+      where.lunchAt = LessThanOrEqual(query.lunchAtTo);
+    }
+
+    if (query.cursor !== undefined) where.id = LessThan(query.cursor);
+
+    return where;
+  }
+
+  async findOpenRoomsCount(): Promise<number> {
+    return await this.roomRepository.count({
+      where: {
+        status: RoomStatus.OPEN,
       },
     });
   }

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -4,8 +4,10 @@ import { RoomRepository } from './room.repository';
 import { DataSource, EntityManager } from 'typeorm';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CreateRoomDto } from './dto/create-room.dto';
+import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { RoomStatus, RoomType } from './entities/room.entity';
 import { RoomMapper } from './mappers/room.mapper';
+import { PAGINATION_CONSTANTS } from './constants/room.constant';
 
 const mockUserSummary = {
   id: 1,
@@ -25,7 +27,7 @@ const mockRoomEntity = {
   minAge: 20,
   maxAge: 24,
   place: '학식당 앞',
-  lunchAt: '2099-03-27T12:30:00.000Z',
+  lunchAt: '2099-03-27T03:30:00.000Z',
   createdAt: '2026-03-27T06:26:40.062Z',
   hostUser: mockUserSummary,
   roomMembers: [
@@ -43,6 +45,23 @@ const mockRoomDetailDto = {
   ...roomEntityBase,
   hostUserId: mockUserSummary.id,
   roomMembers: [mockUserSummary],
+};
+
+const mockRoomListDto = {
+  items: [
+    {
+      ...roomEntityBase,
+      hostUserId: mockUserSummary.id,
+    },
+  ],
+  nextCursor: null,
+  hasNext: false,
+};
+
+const mockSecondRoomEntity = {
+  ...mockRoomEntity,
+  id: 2,
+  title: '두 번째 방',
 };
 
 const createRoomDto: CreateRoomDto = {
@@ -68,6 +87,7 @@ const mockRoomRepository = {
   createRoom: jest.fn(),
   createRoomMember: jest.fn(),
   findRoomById: jest.fn(),
+  findRooms: jest.fn(),
   findParticipatingRoom: jest.fn(),
 };
 
@@ -129,6 +149,92 @@ describe('RoomService', () => {
     });
   });
 
+  describe('findRooms', () => {
+    it('조건에 맞는 방 목록을 반환', async () => {
+      const query: FindRoomsQueryDto = {
+        roomType: RoomType.MALE,
+        status: RoomStatus.OPEN,
+        minAge: 20,
+        maxAge: 24,
+        lunchAtFrom: '2099-03-27T00:00:00.000Z',
+        lunchAtTo: '2099-03-27T23:59:59.999Z',
+      };
+
+      mockRoomRepository.findRooms.mockResolvedValue([mockRoomEntity]);
+      const toListDtoSpy = jest.spyOn(RoomMapper, 'toListDto').mockReturnValue(mockRoomListDto);
+
+      const result = await roomService.findRooms(query);
+
+      expect(result).toEqual(mockRoomListDto);
+      expect(mockRoomRepository.findRooms).toHaveBeenCalledWith(query);
+      expect(toListDtoSpy).toHaveBeenCalledWith([mockRoomEntity], null, false);
+    });
+
+    it('limit보다 많은 방이 조회되면 nextCursor와 hasNext를 반환', async () => {
+      const query: FindRoomsQueryDto = {
+        limit: 1,
+      };
+      const paginatedListDto = {
+        items: [
+          {
+            ...roomEntityBase,
+            id: mockSecondRoomEntity.id,
+            title: mockSecondRoomEntity.title,
+            hostUserId: mockUserSummary.id,
+          },
+        ],
+        nextCursor: mockSecondRoomEntity.id,
+        hasNext: true,
+      };
+
+      mockRoomRepository.findRooms.mockResolvedValue([mockSecondRoomEntity, mockRoomEntity]);
+      const toListDtoSpy = jest.spyOn(RoomMapper, 'toListDto').mockReturnValue(paginatedListDto);
+
+      const result = await roomService.findRooms(query);
+
+      expect(result).toEqual(paginatedListDto);
+      expect(mockRoomRepository.findRooms).toHaveBeenCalledWith(query);
+      expect(toListDtoSpy).toHaveBeenCalledWith(
+        [mockSecondRoomEntity],
+        mockSecondRoomEntity.id,
+        true,
+      );
+    });
+
+    it('limit이 없으면 기본 페이지 크기를 기준으로 페이징', async () => {
+      const query: FindRoomsQueryDto = {};
+      const rooms = Array.from({ length: PAGINATION_CONSTANTS.DEFAULT_LIMIT + 1 }, (_, index) => ({
+        ...mockRoomEntity,
+        id: PAGINATION_CONSTANTS.DEFAULT_LIMIT + 1 - index,
+      }));
+
+      mockRoomRepository.findRooms.mockResolvedValue(rooms);
+      const toListDtoSpy = jest.spyOn(RoomMapper, 'toListDto').mockReturnValue({
+        items: [],
+        nextCursor: 1,
+        hasNext: true,
+      });
+
+      await roomService.findRooms(query);
+
+      expect(toListDtoSpy).toHaveBeenCalledWith(
+        rooms.slice(0, PAGINATION_CONSTANTS.DEFAULT_LIMIT),
+        2,
+        true,
+      );
+    });
+
+    it('조회 시작 시간이 종료 시간보다 늦으면 BadRequestException을 반환', async () => {
+      const query: FindRoomsQueryDto = {
+        lunchAtFrom: '2099-03-27T14:00:00.000Z',
+        lunchAtTo: '2099-03-27T12:00:00.000Z',
+      };
+
+      await expect(roomService.findRooms(query)).rejects.toThrow(BadRequestException);
+      expect(mockRoomRepository.findRooms).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createRoom', () => {
     it('방을 생성하고 생성된 방의 정보를 반환', async () => {
       mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
@@ -171,7 +277,7 @@ describe('RoomService', () => {
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
-    it('방 생성 중 createRoom이 실패하면 예외를 던지고 이후 로직을 실행하지 않는다', async () => {
+    it('방 생성 중 createRoom이 실패하면 예외를 던지고 이후 로직을 실행하지 않음', async () => {
       const createRoomError = new Error('create room failed');
 
       mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
@@ -191,7 +297,7 @@ describe('RoomService', () => {
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('방 생성 중 createRoomMember가 실패하면 예외를 던지고 최종 조회를 실행하지 않는다', async () => {
+    it('방 생성 중 createRoomMember가 실패하면 예외를 던지고 최종 조회를 실행하지 않음', async () => {
       const createRoomMemberError = new Error('create room member failed');
 
       mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
@@ -216,7 +322,7 @@ describe('RoomService', () => {
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('방 생성 후 findRoomById가 null을 반환하면 NotFoundException을 던진다', async () => {
+    it('방 생성 후 findRoomById가 null을 반환하면 NotFoundException을 던짐', async () => {
       mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
       mockRoomRepository.createRoom.mockResolvedValueOnce(mockRoomEntity);
       mockRoomRepository.createRoomMember.mockResolvedValueOnce({

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -1,19 +1,27 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import {
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { RoomService } from './rooms.service';
 import { CreateRoomDto } from './dto/create-room.dto';
-import { ResponseRoomDetailDto } from './dto/room-response.dto';
+import {
+  ResponseOpenRoomsCountDto,
+  ResponseRoomDetailDto,
+  ResponseRoomListDto,
+} from './dto/room-response.dto';
 import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 
 @ApiTags('Room')
+@ApiExtraModels(ResponseRoomListDto, ResponseRoomDetailDto)
 @Controller('rooms')
 export class RoomController {
   constructor(private readonly roomService: RoomService) {}
@@ -29,11 +37,33 @@ export class RoomController {
     return await this.roomService.createRoom(currentUser.userId, createRoomDto);
   }
 
+  @Get()
+  @ApiOperation({ summary: '방 목록 조회' })
+  @ApiQuery({ name: 'cursor', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'roomType', required: false })
+  @ApiQuery({ name: 'status', required: false })
+  @ApiQuery({ name: 'minAge', required: false, type: Number })
+  @ApiQuery({ name: 'maxAge', required: false, type: Number })
+  @ApiQuery({ name: 'lunchAtFrom', required: false, type: String })
+  @ApiQuery({ name: 'lunchAtTo', required: false, type: String })
+  @ApiOkResponse({ type: ResponseRoomListDto })
+  async findRooms(@Query() query: FindRoomsQueryDto): Promise<ResponseRoomListDto> {
+    return await this.roomService.findRooms(query);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: '방 상세 조회' })
   @ApiParam({ name: 'id', description: '조회할 방 ID', type: Number })
   @ApiOkResponse({ type: ResponseRoomDetailDto })
   async findRoomById(@Param('id', ParseIntPipe) roomId: number): Promise<ResponseRoomDetailDto> {
     return await this.roomService.findRoomById(roomId);
+  }
+
+  @Get('count/open')
+  @ApiOperation({ summary: '열려있는 방 갯수 조회' })
+  @ApiOkResponse({ type: ResponseOpenRoomsCountDto })
+  async findOpenRoomsCount(): Promise<ResponseOpenRoomsCountDto> {
+    return await this.roomService.findOpenRoomsCount();
   }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -2,8 +2,15 @@ import { RoomRepository } from './room.repository';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { ResponseRoomDetailDto } from './dto/room-response.dto';
+import dayjs from 'dayjs';
+import {
+  ResponseOpenRoomsCountDto,
+  ResponseRoomDetailDto,
+  ResponseRoomListDto,
+} from './dto/room-response.dto';
 import { RoomMapper } from './mappers/room.mapper';
+import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
+import { PAGINATION_CONSTANTS } from './constants/room.constant';
 
 @Injectable()
 export class RoomService {
@@ -13,10 +20,11 @@ export class RoomService {
   ) {}
 
   async createRoom(userId: number, createRoomDto: CreateRoomDto): Promise<ResponseRoomDetailDto> {
-    if (new Date(createRoomDto.lunchAt) < new Date())
+    if (dayjs(createRoomDto.lunchAt).isBefore(dayjs()))
       throw new BadRequestException('lunchAt은 현재보다 미래여야 합니다.');
+
     if (createRoomDto.minAge > createRoomDto.maxAge)
-      throw new BadRequestException('최소 나이는 최대 나이보다 클 수 없습니다.');
+      throw new BadRequestException('최소 나이와 최대 나이 옵션이 올바르지 않습니다.');
 
     const participatingRoom = await this.roomRepository.findParticipatingRoom(userId);
     if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
@@ -34,11 +42,41 @@ export class RoomService {
     return await this.findRoomById(newRoomId);
   }
 
+  async findRooms(query: FindRoomsQueryDto): Promise<ResponseRoomListDto> {
+    if (query.minAge !== undefined && query.maxAge !== undefined && query.minAge > query.maxAge) {
+      throw new BadRequestException('최소 나이와 최대 나이 옵션이 올바르지 않습니다.');
+    }
+
+    if (
+      query.lunchAtFrom !== undefined &&
+      query.lunchAtTo !== undefined &&
+      dayjs(query.lunchAtFrom).isAfter(dayjs(query.lunchAtTo))
+    ) {
+      throw new BadRequestException('lunchAt 옵션이 올바르지 않습니다.');
+    }
+
+    const limit = query.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
+    const rooms = (await this.roomRepository.findRooms(query)) || [];
+    const hasNext = rooms.length > limit;
+    const paginatedRooms = hasNext ? rooms.slice(0, limit) : rooms;
+    const nextCursor = hasNext ? paginatedRooms[paginatedRooms.length - 1].id : null;
+
+    return RoomMapper.toListDto(paginatedRooms, nextCursor, hasNext);
+  }
+
   async findRoomById(roomId: number): Promise<ResponseRoomDetailDto> {
     const room = await this.roomRepository.findRoomById(roomId);
 
     if (!room) throw new NotFoundException(`존재하지 않는 방입니다.`);
 
     return RoomMapper.toDetailDto(room);
+  }
+
+  async findOpenRoomsCount(): Promise<ResponseOpenRoomsCountDto> {
+    const openRoomsCount = (await this.roomRepository.findOpenRoomsCount()) || 0;
+
+    return {
+      openRoomsCount,
+    };
   }
 }

--- a/test/rooms.e2e-spec.ts
+++ b/test/rooms.e2e-spec.ts
@@ -3,7 +3,7 @@ import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { RoomMember } from '../src/rooms/entities/room-member.entity';
-import { Room } from '../src/rooms/entities/room.entity';
+import { Room, RoomStatus, RoomType } from '../src/rooms/entities/room.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
 
@@ -15,6 +15,39 @@ describe('Rooms (e2e)', () => {
   const httpApp = () => app.getHttpAdapter().getInstance();
   const futureLunchAt = (hoursFromNow: number) =>
     new Date(Date.now() + hoursFromNow * 60 * 60 * 1000).toISOString();
+  const signupUser = async (email: string, nickname: string) => {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  };
+
+  const createRoomFixture = async (hostUser: User, overrides?: Partial<Room>): Promise<Room> => {
+    const room = await dataSource.getRepository(Room).save({
+      title: overrides?.title ?? '밥 같이 먹을 사람',
+      description: overrides?.description ?? '난 컴소과',
+      roomType: overrides?.roomType ?? RoomType.MALE,
+      maxMembersCount: overrides?.maxMembersCount ?? 4,
+      minAge: overrides?.minAge ?? 20,
+      maxAge: overrides?.maxAge ?? 24,
+      place: overrides?.place ?? '학식당 앞',
+      lunchAt: overrides?.lunchAt ?? futureLunchAt(1),
+      status: overrides?.status ?? RoomStatus.OPEN,
+      currentMembersCount: overrides?.currentMembersCount ?? 1,
+      hostUser,
+    });
+
+    await dataSource.getRepository(RoomMember).save({
+      room,
+      user: hostUser,
+    });
+
+    return room;
+  };
 
   beforeAll(async () => {
     app = (await createAuthUserTestApp()) as INestApplication<App>;
@@ -32,6 +65,8 @@ describe('Rooms (e2e)', () => {
   });
 
   it('POST /rooms 방 생성 성공', async () => {
+    const lunchAt = futureLunchAt(1);
+
     const signupResponse = await request(httpApp()).post('/auth/signup').send({
       email: 'test123@gmail.com',
       password: '1q2w3e4r',
@@ -50,7 +85,7 @@ describe('Rooms (e2e)', () => {
         roomType: 'MALE',
         maxMembersCount: 4,
         place: '학식당 앞',
-        lunchAt: futureLunchAt(1),
+        lunchAt,
         minAge: 20,
         maxAge: 24,
       });
@@ -62,6 +97,7 @@ describe('Rooms (e2e)', () => {
     expect(response.body.currentMembersCount).toBe(1);
     expect(response.body.roomMembers).toHaveLength(1);
     expect(response.body.roomMembers[0].nickname).toBe('길동홍');
+    expect(response.body.lunchAt).toBe(lunchAt);
 
     const createdRoom = await dataSource.getRepository(Room).findOne({
       where: { id: response.body.id },
@@ -72,6 +108,7 @@ describe('Rooms (e2e)', () => {
 
     expect(createdRoom).not.toBeNull();
     expect(createdRoom?.hostUser.id).toBe(signupResponse.body.user.id);
+    expect(response.body.createdAt).toBe(new Date(createdRoom!.createdAt).toISOString());
   });
 
   it('POST /rooms 이미 참여 중인 방이 있으면 생성 실패', async () => {
@@ -120,5 +157,88 @@ describe('Rooms (e2e)', () => {
     const roomCount = await dataSource.getRepository(Room).count();
 
     expect(roomCount).toBe(1);
+  });
+
+  it('GET /rooms 방 목록을 cursor pagination으로 조회', async () => {
+    const signupResponse = await signupUser('test@gmail.com', '목록호스트');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const firstLunchAt = futureLunchAt(1);
+    const secondLunchAt = futureLunchAt(2);
+    const thirdLunchAt = futureLunchAt(3);
+
+    const firstRoom = await createRoomFixture(hostUser, {
+      title: '첫 번째 방',
+      currentMembersCount: 2,
+      lunchAt: firstLunchAt,
+    });
+    const secondRoom = await createRoomFixture(hostUser, {
+      title: '두 번째 방',
+      currentMembersCount: 3,
+      lunchAt: secondLunchAt,
+    });
+    const thirdRoom = await createRoomFixture(hostUser, {
+      title: '세 번째 방',
+      currentMembersCount: 4,
+      roomType: RoomType.FEMALE,
+      lunchAt: thirdLunchAt,
+    });
+
+    const response = await request(httpApp()).get('/rooms').query({
+      limit: 2,
+      status: RoomStatus.OPEN,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0].id).toBe(thirdRoom.id);
+    expect(response.body.items[0].title).toBe('세 번째 방');
+    expect(response.body.items[0].lunchAt).toBe(thirdLunchAt);
+    expect(response.body.items[1].id).toBe(secondRoom.id);
+    expect(response.body.items[1].lunchAt).toBe(secondLunchAt);
+    expect(response.body.hasNext).toBe(true);
+    expect(response.body.nextCursor).toBe(secondRoom.id);
+
+    const nextPageResponse = await request(httpApp()).get('/rooms').query({
+      cursor: response.body.nextCursor,
+      limit: 2,
+      status: RoomStatus.OPEN,
+    });
+
+    expect(nextPageResponse.status).toBe(200);
+    expect(nextPageResponse.body.items).toHaveLength(1);
+    expect(nextPageResponse.body.items[0].id).toBe(firstRoom.id);
+    expect(nextPageResponse.body.items[0].lunchAt).toBe(firstLunchAt);
+    expect(nextPageResponse.body.hasNext).toBe(false);
+    expect(nextPageResponse.body.nextCursor).toBeNull();
+  });
+
+  it('GET /rooms/:id 방 상세 정보를 조회한다', async () => {
+    const signupResponse = await signupUser('test@gmail.com', '상세호스트');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const lunchAt = futureLunchAt(1);
+
+    const room = await createRoomFixture(hostUser, {
+      title: '상세 조회 방',
+      description: '상세 설명',
+      currentMembersCount: 1,
+      lunchAt,
+    });
+
+    const response = await request(httpApp()).get(`/rooms/${room.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(room.id);
+    expect(response.body.title).toBe('상세 조회 방');
+    expect(response.body.description).toBe('상세 설명');
+    expect(response.body.hostUserId).toBe(hostUser.id);
+    expect(response.body.currentMembersCount).toBe(1);
+    expect(response.body.lunchAt).toBe(lunchAt);
+    expect(response.body.createdAt).toBe(new Date(room.createdAt).toISOString());
+    expect(response.body.roomMembers).toHaveLength(1);
+    expect(response.body.roomMembers[0].nickname).toBe('상세호스트');
   });
 });


### PR DESCRIPTION
## 연관된 이슈

- #49 

## 📝 작업 내용

- [x] `GET /rooms` 방 목록 조회 API 구현
- [x] `GET /rooms/:id` 방 상세 조회 API 구현
- [x] `GET /rooms/open/count` 열린 방 개수 조회 API 구현
- [x] 방 목록 조회용 `FindRoomsQueryDto` 작성
- [x] 방 목록/상세 조회 응답 DTO 작성
- [x] Room 조회용 mapper 구현
- [x] 방 목록 조회 필터 조건 추가
  - [x] `roomType`, `status` 필터 추가
  - [x] `minAge`, `maxAge` 필터 추가
  - [x] `lunchAtFrom`, `lunchAtTo` 시간 범위 필터 추가
- [x] cursor pagination 적용
- [x] 예외 처리
  - [x] `minAge > maxAge` 예외 처리 추가
  - [x] `lunchAtFrom > lunchAtTo` 예외 처리 추가
- [x] `RoomService` 테스트 추가
- [x] `RoomRepository` 테스트 추가
- [x] 방 조회 e2e 테스트 추가
