### PR TITLE
Auth User 에러 응답 테스트 강화

### DIFF
--- a/test/auth-users.e2e-spec.ts
+++ b/test/auth-users.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { AUTH_ERROR_MESSAGES } from '../src/auth/auth.constants';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
 
@@ -23,6 +24,19 @@ describe('Auth and Users (e2e)', () => {
   beforeEach(async () => {
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   it('회원가입 성공', async () => {
     const response = await request(app.getHttpServer()).post('/auth/signup').send({
@@ -73,7 +87,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expect(response.status).toBe(409);
+    expectErrorResponse(response, 409, 'Email already exists.');
   });
 
   it('닉네임 중복 회원가입 실패', async () => {
@@ -95,7 +109,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expect(response.status).toBe(409);
+    expectErrorResponse(response, 409, 'Nickname already exists.');
   });
 
   it('로그인 성공', async () => {
@@ -134,7 +148,7 @@ describe('Auth and Users (e2e)', () => {
       password: 'invalid-password',
     });
 
-    expect(response.status).toBe(401);
+    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 
   it('존재하지 않는 사용자 로그인 실패', async () => {
@@ -143,7 +157,7 @@ describe('Auth and Users (e2e)', () => {
       password: 'password1234',
     });
 
-    expect(response.status).toBe(401);
+    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 
   it('refresh 성공 및 새 access token 발급', async () => {
@@ -169,7 +183,7 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: signupResponse.body.refreshToken,
     });
 
-    expect(reusedRefreshResponse.status).toBe(401);
+    expectErrorResponse(reusedRefreshResponse, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
   });
 
   it('잘못된 refresh token 거부', async () => {
@@ -177,7 +191,7 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: 'invalid.refresh.token.value',
     });
 
-    expect(response.status).toBe(401);
+    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
   });
 
   it('로그아웃 후 refresh 재사용 실패', async () => {
@@ -200,13 +214,13 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: signupResponse.body.refreshToken,
     });
 
-    expect(refreshResponse.status).toBe(401);
+    expectErrorResponse(refreshResponse, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
 
     const logoutAgainResponse = await request(app.getHttpServer())
       .post('/auth/logout')
       .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
 
-    expect(logoutAgainResponse.status).toBe(401);
+    expectErrorResponse(logoutAgainResponse, 401, 'Unauthorized');
   });
 
   it('같은 refresh token 동시 요청 시 한 번만 성공', async () => {
@@ -260,7 +274,7 @@ describe('Auth and Users (e2e)', () => {
   it('GET /users/me 인증 없이 접근 시 401', async () => {
     const response = await request(app.getHttpServer()).get('/users/me');
 
-    expect(response.status).toBe(401);
+    expectErrorResponse(response, 401, 'Unauthorized');
   });
 
   it('PATCH /users/me 프로필 수정 성공', async () => {
@@ -314,7 +328,7 @@ describe('Auth and Users (e2e)', () => {
         nickname: 'taken-nickname',
       });
 
-    expect(response.status).toBe(409);
+    expectErrorResponse(response, 409, 'Nickname already exists.');
   });
 
   it('DELETE /users/me 후 soft delete 반영 및 재로그인 실패', async () => {
@@ -348,6 +362,6 @@ describe('Auth and Users (e2e)', () => {
       password: 'password1234',
     });
 
-    expect(loginResponse.status).toBe(401);
+    expectErrorResponse(loginResponse, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 });

--- a/test/auth-users.e2e-spec.ts
+++ b/test/auth-users.e2e-spec.ts
@@ -25,7 +25,8 @@ describe('Auth and Users (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
 
-  function expectErrorResponse(
+  // Assert the error response shape produced by AllExceptionFilter.
+  function expectExceptionFilterErrorResponse(
     response: request.Response,
     statusCode: number,
     message: string,
@@ -87,7 +88,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expectErrorResponse(response, 409, 'Email already exists.');
+    expectExceptionFilterErrorResponse(response, 409, 'Email already exists.');
   });
 
   it('닉네임 중복 회원가입 실패', async () => {
@@ -109,7 +110,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expectErrorResponse(response, 409, 'Nickname already exists.');
+    expectExceptionFilterErrorResponse(response, 409, 'Nickname already exists.');
   });
 
   it('로그인 성공', async () => {
@@ -148,7 +149,7 @@ describe('Auth and Users (e2e)', () => {
       password: 'invalid-password',
     });
 
-    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
+    expectExceptionFilterErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 
   it('존재하지 않는 사용자 로그인 실패', async () => {
@@ -157,7 +158,7 @@ describe('Auth and Users (e2e)', () => {
       password: 'password1234',
     });
 
-    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
+    expectExceptionFilterErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 
   it('refresh 성공 및 새 access token 발급', async () => {
@@ -183,7 +184,11 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: signupResponse.body.refreshToken,
     });
 
-    expectErrorResponse(reusedRefreshResponse, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
+    expectExceptionFilterErrorResponse(
+      reusedRefreshResponse,
+      401,
+      AUTH_ERROR_MESSAGES.invalidRefreshToken,
+    );
   });
 
   it('잘못된 refresh token 거부', async () => {
@@ -191,7 +196,7 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: 'invalid.refresh.token.value',
     });
 
-    expectErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
+    expectExceptionFilterErrorResponse(response, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
   });
 
   it('로그아웃 후 refresh 재사용 실패', async () => {
@@ -214,13 +219,17 @@ describe('Auth and Users (e2e)', () => {
       refreshToken: signupResponse.body.refreshToken,
     });
 
-    expectErrorResponse(refreshResponse, 401, AUTH_ERROR_MESSAGES.invalidRefreshToken);
+    expectExceptionFilterErrorResponse(
+      refreshResponse,
+      401,
+      AUTH_ERROR_MESSAGES.invalidRefreshToken,
+    );
 
     const logoutAgainResponse = await request(app.getHttpServer())
       .post('/auth/logout')
       .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
 
-    expectErrorResponse(logoutAgainResponse, 401, 'Unauthorized');
+    expectExceptionFilterErrorResponse(logoutAgainResponse, 401, 'Unauthorized');
   });
 
   it('같은 refresh token 동시 요청 시 한 번만 성공', async () => {
@@ -274,7 +283,7 @@ describe('Auth and Users (e2e)', () => {
   it('GET /users/me 인증 없이 접근 시 401', async () => {
     const response = await request(app.getHttpServer()).get('/users/me');
 
-    expectErrorResponse(response, 401, 'Unauthorized');
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 
   it('PATCH /users/me 프로필 수정 성공', async () => {
@@ -328,7 +337,7 @@ describe('Auth and Users (e2e)', () => {
         nickname: 'taken-nickname',
       });
 
-    expectErrorResponse(response, 409, 'Nickname already exists.');
+    expectExceptionFilterErrorResponse(response, 409, 'Nickname already exists.');
   });
 
   it('DELETE /users/me 후 soft delete 반영 및 재로그인 실패', async () => {
@@ -362,6 +371,6 @@ describe('Auth and Users (e2e)', () => {
       password: 'password1234',
     });
 
-    expectErrorResponse(loginResponse, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
+    expectExceptionFilterErrorResponse(loginResponse, 401, AUTH_ERROR_MESSAGES.invalidCredentials);
   });
 });

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -1,13 +1,17 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { WinstonModule } from 'nest-winston';
 import { newDb } from 'pg-mem';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { AppController } from '../src/app.controller';
 import { AppService } from '../src/app.service';
 import { AuthModule } from '../src/auth/auth.module';
+import { AllExceptionFilter } from '../src/commons/filters/all-exception.filter';
 import { validationPipeOptions } from '../src/commons/validation/validation-pipe-options';
+import { winstonOptions } from '../src/config/winston.config';
 import { CommentLike } from '../src/comments/entities/comment-like.entity';
 import { Comment } from '../src/comments/entities/comment.entity';
 import { Friend } from '../src/friends/entities/friend.entity';
@@ -63,6 +67,9 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
         isGlobal: true,
         ignoreEnvFile: true,
       }),
+      WinstonModule.forRoot({
+        transports: winstonOptions,
+      }),
       TypeOrmModule.forRootAsync({
         useFactory: () => ({
           type: 'postgres',
@@ -97,6 +104,12 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
       AuthModule,
       RoomModule,
       FriendModule,
+    ],
+    providers: [
+      {
+        provide: APP_FILTER,
+        useClass: AllExceptionFilter,
+      },
     ],
   }).compile();
 


### PR DESCRIPTION
## 연관된 이슈

- #59

## 📝 작업 내용

- [x] `401` 외 `error.message` 검증 추가
- [x] 필요 시 `error.statusCode` 검증 추가
- [x] 로그인/refresh/logout 등 인증 실패 케이스 정리
- [x] 전역 예외 필터 응답 shape와 테스트 정렬
