### PR TITLE
방 삭제 API 구현 및 응답 매핑 인터셉터 구현

### DIFF
--- a/src/commons/decorators/response-message.decorator.ts
+++ b/src/commons/decorators/response-message.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ResponseMessage = (message: string) => SetMetadata('response-message', message);

--- a/src/commons/interceptors/response-transform.interceptor.ts
+++ b/src/commons/interceptors/response-transform.interceptor.ts
@@ -1,0 +1,27 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface Response<T> {
+  message: string;
+  statusCode: number;
+  data: T;
+}
+
+@Injectable()
+export class ResponseTransformInterceptor<T> implements NestInterceptor<T, Response<T>> {
+  constructor(private reflector: Reflector) {}
+  intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
+    const statusCode = context.switchToHttp().getResponse().statusCode;
+    const message = this.reflector.get<string>('response-message', context.getHandler());
+
+    return next.handle().pipe(
+      map((data) => ({
+        message: message || data.message || 'success',
+        statusCode,
+        data: data.data || data,
+      })),
+    );
+  }
+}

--- a/src/commons/interceptors/response-transform.interceptor.ts
+++ b/src/commons/interceptors/response-transform.interceptor.ts
@@ -18,9 +18,9 @@ export class ResponseTransformInterceptor<T> implements NestInterceptor<T, Respo
 
     return next.handle().pipe(
       map((data) => ({
-        message: message || data.message || 'success',
+        message: message ?? data?.message ?? 'success',
         statusCode,
-        data: data.data || data,
+        data: data?.data ?? data ?? null,
       })),
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { ValidationPipe } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AppModule } from './app.module';
+import { ResponseTransformInterceptor } from './commons/interceptors/response-transform.interceptor';
 import { validationPipeOptions } from './commons/validation/validation-pipe-options';
 import { winstonLogger } from './config/winston.config';
 
@@ -12,8 +13,8 @@ async function bootstrap() {
   });
 
   app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
+  app.useGlobalInterceptors(new ResponseTransformInterceptor(app.get(Reflector)));
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
-
   const swaggerConfig = new DocumentBuilder()
     .setTitle('Lunch Mate API')
     .setDescription('Lunch Mate backend API documentation')

--- a/src/rooms/room.repository.spec.ts
+++ b/src/rooms/room.repository.spec.ts
@@ -7,11 +7,12 @@ import { UpdateRoomDto } from './dto/update-room.dto';
 
 describe('RoomRepository', () => {
   let roomRepository: RoomRepository;
-  let roomOrmRepository: Pick<Repository<Room>, 'update'>;
+  let roomOrmRepository: Pick<Repository<Room>, 'update' | 'softDelete'>;
 
   beforeEach(() => {
     roomOrmRepository = {
       update: jest.fn(),
+      softDelete: jest.fn(),
     };
 
     roomRepository = new RoomRepository(
@@ -88,6 +89,22 @@ describe('RoomRepository', () => {
 
       expect(result).toEqual(updateResult);
       expect(roomOrmRepository.update).toHaveBeenCalledWith(roomId, updateRoomDto);
+    });
+  });
+
+  describe('deleteRoom', () => {
+    it('roomId로 softDelete를 호출', async () => {
+      const roomId = 1;
+      const deleteResult = {
+        affected: 1,
+      };
+
+      (roomOrmRepository.softDelete as jest.Mock).mockResolvedValue(deleteResult);
+
+      const result = await roomRepository.deleteRoom(roomId);
+
+      expect(result).toEqual(deleteResult);
+      expect(roomOrmRepository.softDelete).toHaveBeenCalledWith(roomId);
     });
   });
 });

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -7,6 +7,7 @@ import { RoomMember } from './entities/room-member.entity';
 import { Room, RoomStatus } from './entities/room.entity';
 import {
   Between,
+  DeleteResult,
   EntityManager,
   FindOptionsWhere,
   LessThan,
@@ -120,5 +121,9 @@ export class RoomRepository {
 
   async updateRoom(roomId: number, updateRoomDto: UpdateRoomDto): Promise<UpdateResult> {
     return await this.roomRepository.update(roomId, updateRoomDto);
+  }
+
+  async deleteRoom(roomId: number): Promise<DeleteResult> {
+    return await this.roomRepository.softDelete(roomId);
   }
 }

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoomService } from './rooms.service';
 import { RoomRepository } from './room.repository';
-import { DataSource, EntityManager } from 'typeorm';
+import { DataSource, DeleteResult, EntityManager } from 'typeorm';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
@@ -91,6 +91,7 @@ const mockRoomRepository = {
   findRooms: jest.fn(),
   findParticipatingRoom: jest.fn(),
   updateRoom: jest.fn(),
+  deleteRoom: jest.fn(),
 };
 
 describe('RoomService', () => {
@@ -268,7 +269,7 @@ describe('RoomService', () => {
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('이미 창여중인 방이 있는 사용자가 방을 생성하면 BadRequestException을 반환', async () => {
+    it('이미 참여중인 방이 있는 사용자가 방을 생성하면 BadRequestException을 반환', async () => {
       mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce({ id: 99 });
 
       await expect(roomService.createRoom(mockUserSummary.id, createRoomDto)).rejects.toThrow(
@@ -350,6 +351,35 @@ describe('RoomService', () => {
       );
       expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('최소 나이가 최대 나이보다 크면 BadRequestException을 반환', async () => {
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+
+      await expect(
+        roomService.createRoom(mockUserSummary.id, {
+          ...createRoomDto,
+          minAge: 30,
+          maxAge: 24,
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('과거 lunchAt으로 방을 생성하면 BadRequestException을 반환', async () => {
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+
+      await expect(
+        roomService.createRoom(mockUserSummary.id, {
+          ...createRoomDto,
+          lunchAt: '2026-03-26T23:59:59.999Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
   });
 
@@ -454,6 +484,55 @@ describe('RoomService', () => {
 
       expect(result).toEqual(mockRoomDetailDto);
       expect(mockRoomRepository.updateRoom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteRoom', () => {
+    const deleteResult: DeleteResult = {
+      raw: [],
+      affected: 1,
+    };
+
+    it('방장이 방을 삭제하면 repository deleteRoom을 호출', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.deleteRoom.mockResolvedValueOnce(deleteResult);
+
+      await roomService.deleteRoom(mockRoomEntity.id, mockUserSummary.id);
+
+      expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
+      expect(mockRoomRepository.deleteRoom).toHaveBeenCalledWith(mockRoomEntity.id);
+    });
+
+    it('방장이 아닌 사용자가 삭제하면 ForbiddenException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+
+      await expect(roomService.deleteRoom(mockRoomEntity.id, 999)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockRoomRepository.deleteRoom).not.toHaveBeenCalled();
+    });
+
+    it('존재하지 않는 방을 삭제하면 NotFoundException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(null);
+
+      await expect(roomService.deleteRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockRoomRepository.deleteRoom).not.toHaveBeenCalled();
+    });
+
+    it('삭제 결과 affected가 0이면 NotFoundException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.deleteRoom.mockResolvedValueOnce({
+        raw: [],
+        affected: 0,
+      });
+
+      await expect(roomService.deleteRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -1,10 +1,22 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBody,
   ApiCreatedResponse,
   ApiExtraModels,
   ApiForbiddenResponse,
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -95,5 +107,24 @@ export class RoomController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponseRoomDetailDto> {
     return await this.roomService.updateRoom(roomId, updateRoomDto, user.userId);
+  }
+
+  @Delete(':id')
+  @Authenticated()
+  @HttpCode(204)
+  @ApiOperation({
+    summary: '방 삭제',
+    description: '방장만 방을 삭제할 수 있으며, 성공 시 응답 본문 없이 204 No Content를 반환',
+  })
+  @ApiParam({ name: 'id', description: '삭제할 방 ID', type: Number })
+  @ApiNoContentResponse({ description: '방 삭제 성공, 응답 본문은 반환되지 않음' })
+  @ApiForbiddenResponse({ description: '방장이 아닌 사용자가 삭제를 시도한 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 방을 삭제하려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async deleteRoom(
+    @Param('id', ParseIntPipe) roomId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    await this.roomService.deleteRoom(roomId, user.userId);
   }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -114,4 +114,15 @@ export class RoomService {
     if (dto.lunchAt && dayjs(dto.lunchAt).isBefore(dayjs()))
       throw new BadRequestException('lunchAt은 현재보다 미래여야 합니다.');
   }
+
+  async deleteRoom(roomId: number, userId: number) {
+    const existingRoom = await this.roomRepository.findRoomById(roomId);
+    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
+
+    if (existingRoom.hostUser.id !== userId)
+      throw new ForbiddenException('방장만 방을 삭제할 수 있습니다.');
+
+    const deletedRoom = await this.roomRepository.deleteRoom(roomId);
+    if (!deletedRoom.affected) throw new NotFoundException('존재하지 않는 방입니다.');
+  }
 }

--- a/test/rooms-delete.e2e-spec.ts
+++ b/test/rooms-delete.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { Room } from '../src/rooms/entities/room.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+import { clearRoomTables, createRoomFixture, signupUser } from './rooms.e2e-helper';
+
+jest.setTimeout(30000);
+
+describe('Rooms Delete (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+  const httpApp = () => app.getHttpAdapter().getInstance();
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await clearRoomTables(dataSource);
+  });
+
+  it('DELETE /rooms/:id 방장이 방을 삭제한다', async () => {
+    const signupResponse = await signupUser(httpApp, 'host-delete@gmail.com', '삭제방장');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      title: '삭제 대상 방',
+    });
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(204);
+
+    const deletedRoom = await dataSource.getRepository(Room).findOneBy({
+      id: room.id,
+    });
+
+    expect(deletedRoom).toBeNull();
+  });
+
+  it('DELETE /rooms/:id 방장이 아닌 사용자가 삭제하면 실패한다', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host-delete-forbidden@gmail.com', '방장');
+    const otherSignupResponse = await signupUser(httpApp, 'guest-delete-forbidden@gmail.com', '일반유저');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      title: '삭제 권한 체크 방',
+    });
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}`)
+      .set('Authorization', `Bearer ${otherSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe('방장만 방을 삭제할 수 있습니다.');
+  });
+
+  it('DELETE /rooms/:id 존재하지 않는 방을 삭제하면 실패한다', async () => {
+    const signupResponse = await signupUser(httpApp, 'host-delete-notfound@gmail.com', '없는방삭제');
+
+    const response = await request(httpApp())
+      .delete('/rooms/999999')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('존재하지 않는 방입니다.');
+  });
+});

--- a/test/rooms-update.e2e-spec.ts
+++ b/test/rooms-update.e2e-spec.ts
@@ -68,7 +68,7 @@ describe('Rooms Update (e2e)', () => {
     expect(updatedRoom.description).toBe('수정 후 설명');
     expect(updatedRoom.minAge).toBe(21);
     expect(updatedRoom.maxAge).toBe(25);
-    expect(updatedRoom.lunchAt).toBe(updatedLunchAt);
+    expect(updatedRoom.lunchAt.toISOString()).toBe(updatedLunchAt);
   });
 
   it('PATCH /rooms/:id 방장이 아닌 사용자가 수정하면 실패', async () => {


### PR DESCRIPTION
## 연관된 이슈

- #72 

## 📝 작업 내용

- [x] 전역 응답 매핑 인터셉터 구현 및 글로벌 적용
- [x] 응답 메시지를 받는 ResponseMessage 데코레이터 구현
- [x] `DELETE /rooms/:id` 방 삭제 API 구현
- [x] 방 삭제 Swagger 문서화 추가
- [x] 방 존재 여부 검증 추가
- [x] 방장(호스트)만 삭제 가능하도록 권한 검증 추가
- [x] `softDelete` 기반 삭제 로직 반영
- [x] 존재하지 않는 방 삭제 요청 예외 처리 추가
- [x] 방장이 아닌 사용자의 삭제 요청 예외 처리 추가
- [x] `RoomService`, `RoomRepository` 방 삭제 테스트 코드 추가
- [x] 방 삭제 e2e 테스트 코드 추가
