### PR TITLE
방 참여/나가기 API 구현

### DIFF
--- a/migrations/1775114078934-AddHostUserIdToRoom.ts
+++ b/migrations/1775114078934-AddHostUserIdToRoom.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddHostUserIdToRoom1775114078934 implements MigrationInterface {
+    name = 'AddHostUserIdToRoom1775114078934'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" ADD "post_id" integer`);
+        await queryRunner.query(`ALTER TABLE "comments" ADD "user_id" integer`);
+        await queryRunner.query(`ALTER TABLE "comments" ADD CONSTRAINT "FK_259bf9825d9d198608d1b46b0b5" FOREIGN KEY ("post_id") REFERENCES "posts"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "comments" ADD CONSTRAINT "FK_4c675567d2a58f0b07cef09c13d" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" DROP CONSTRAINT "FK_4c675567d2a58f0b07cef09c13d"`);
+        await queryRunner.query(`ALTER TABLE "comments" DROP CONSTRAINT "FK_259bf9825d9d198608d1b46b0b5"`);
+        await queryRunner.query(`ALTER TABLE "comments" DROP COLUMN "user_id"`);
+        await queryRunner.query(`ALTER TABLE "comments" DROP COLUMN "post_id"`);
+    }
+
+}

--- a/migrations/1775114685192-AlterHostUserIdInRoom.ts
+++ b/migrations/1775114685192-AlterHostUserIdInRoom.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AlterHostUserIdInRoom1775114685192 implements MigrationInterface {
+    name = 'AlterHostUserIdInRoom1775114685192'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "rooms" DROP CONSTRAINT "FK_08815b6b09a529e7ef5bcf3c492"`);
+        await queryRunner.query(`ALTER TABLE "rooms" ALTER COLUMN "host_user_id" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "rooms" ADD CONSTRAINT "FK_08815b6b09a529e7ef5bcf3c492" FOREIGN KEY ("host_user_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "rooms" DROP CONSTRAINT "FK_08815b6b09a529e7ef5bcf3c492"`);
+        await queryRunner.query(`ALTER TABLE "rooms" ALTER COLUMN "host_user_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "rooms" ADD CONSTRAINT "FK_08815b6b09a529e7ef5bcf3c492" FOREIGN KEY ("host_user_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/commons/utils/age.util.ts
+++ b/src/commons/utils/age.util.ts
@@ -1,0 +1,8 @@
+export function calculateAge(birthDate: string | Date): number {
+  const today = new Date();
+  const birth = new Date(birthDate);
+
+  const age = today.getFullYear() - birth.getFullYear() + 1;
+
+  return age;
+}

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -1,14 +1,6 @@
 import { BaseTableEntity } from '../../commons/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  ManyToOne,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  RelationId,
-} from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { RoomMember } from './room-member.entity';
 
 export enum RoomType {
@@ -85,6 +77,6 @@ export class Room extends BaseTableEntity {
   @JoinColumn({ name: 'host_user_id' })
   hostUser: User;
 
-  @RelationId((room: Room) => room.hostUser)
+  @Column({ name: 'host_user_id' })
   hostUserId: number;
 }

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -1,6 +1,14 @@
 import { BaseTableEntity } from '../../commons/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  RelationId,
+} from 'typeorm';
 import { RoomMember } from './room-member.entity';
 
 export enum RoomType {
@@ -76,4 +84,7 @@ export class Room extends BaseTableEntity {
   @ManyToOne(() => User, (user) => user.rooms)
   @JoinColumn({ name: 'host_user_id' })
   hostUser: User;
+
+  @RelationId((room: Room) => room.hostUser)
+  hostUserId: number;
 }

--- a/src/rooms/room.repository.spec.ts
+++ b/src/rooms/room.repository.spec.ts
@@ -8,6 +8,9 @@ import { UpdateRoomDto } from './dto/update-room.dto';
 describe('RoomRepository', () => {
   let roomRepository: RoomRepository;
   let roomOrmRepository: Pick<Repository<Room>, 'update' | 'softDelete'>;
+  const manager = {
+    update: jest.fn(),
+  };
 
   beforeEach(() => {
     roomOrmRepository = {
@@ -105,6 +108,23 @@ describe('RoomRepository', () => {
 
       expect(result).toEqual(deleteResult);
       expect(roomOrmRepository.softDelete).toHaveBeenCalledWith(roomId);
+    });
+  });
+
+  describe('updateRoomHostUser', () => {
+    it('roomId와 새로운 hostUserId로 host를 변경', async () => {
+      const updateResult = {
+        affected: 1,
+      };
+
+      (manager.update as jest.Mock).mockResolvedValue(updateResult);
+
+      const result = await roomRepository.updateRoomHostUser(manager as never, 1, 2);
+
+      expect(result).toEqual(updateResult);
+      expect(manager.update).toHaveBeenCalledWith(Room, 1, {
+        hostUserId: 2,
+      });
     });
   });
 });

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -123,7 +123,25 @@ export class RoomRepository {
     return await this.roomRepository.update(roomId, updateRoomDto);
   }
 
-  async deleteRoom(roomId: number): Promise<DeleteResult> {
+  async deleteRoom(roomId: number, manager?: EntityManager): Promise<DeleteResult> {
+    if (manager) {
+      return await manager.softDelete(Room, roomId);
+    }
+
     return await this.roomRepository.softDelete(roomId);
+  }
+
+  async increaseCurrentMembersCount(manager: EntityManager, roomId: number) {
+    return await manager.increment(Room, { id: roomId }, 'currentMembersCount', 1);
+  }
+
+  async decreaseCurrentMembersCount(manager: EntityManager, roomId: number) {
+    return await manager.decrement(Room, { id: roomId }, 'currentMembersCount', 1);
+  }
+
+  async updateRoomHostUser(manager: EntityManager, roomId: number, newHostUserId: number) {
+    return await manager.update(Room, roomId, {
+      hostUserId: newHostUserId,
+    });
   }
 }

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -9,6 +9,8 @@ import { UpdateRoomDto } from './dto/update-room.dto';
 import { RoomStatus, RoomType } from './entities/room.entity';
 import { RoomMapper } from './mappers/room.mapper';
 import { PAGINATION_CONSTANTS } from './constants/room.constant';
+import { RoomMemberService } from './roomMember.service';
+import { UserService } from '../users/users.service';
 
 const mockUserSummary = {
   id: 1,
@@ -92,6 +94,21 @@ const mockRoomRepository = {
   findParticipatingRoom: jest.fn(),
   updateRoom: jest.fn(),
   deleteRoom: jest.fn(),
+  increaseCurrentMembersCount: jest.fn(),
+  decreaseCurrentMembersCount: jest.fn(),
+  updateRoomHostUser: jest.fn(),
+};
+
+const mockRoomMemberService = {
+  findRoomMemberCount: jest.fn(),
+  joinRoom: jest.fn(),
+  leaveRoom: jest.fn(),
+  isRoomMember: jest.fn(),
+  findFirstJoinedMemberId: jest.fn(),
+};
+
+const mockUserService = {
+  findMe: jest.fn(),
 };
 
 describe('RoomService', () => {
@@ -102,7 +119,7 @@ describe('RoomService', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-03-27T00:00:00.000Z'));
     jest.restoreAllMocks();
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     roomMapperSpy = jest.spyOn(RoomMapper, 'toDetailDto');
 
     mockDataSource.transaction.mockImplementation(
@@ -121,6 +138,14 @@ describe('RoomService', () => {
         {
           provide: RoomRepository,
           useValue: mockRoomRepository,
+        },
+        {
+          provide: RoomMemberService,
+          useValue: mockRoomMemberService,
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService,
         },
       ],
     }).compile();
@@ -533,6 +558,172 @@ describe('RoomService', () => {
       await expect(roomService.deleteRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('joinRoom', () => {
+    const mockCurrentUser = {
+      id: mockUserSummary.id,
+      email: 'test@gmail.com',
+      nickname: mockUserSummary.nickname,
+      gender: 'MALE' as const,
+      birthDate: '2005-01-01',
+      schoolInfo: mockUserSummary.schoolInfo,
+    };
+
+    it('사용자가 방에 참여하면 멤버를 생성하고 반환', async () => {
+      const newMember = {
+        id: 10,
+        room: { id: mockRoomEntity.id },
+        user: { id: mockUserSummary.id },
+      };
+
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(1);
+      mockRoomRepository.increaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.joinRoom.mockResolvedValueOnce(newMember);
+
+      const result = await roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id);
+
+      expect(result).toEqual(newMember);
+      expect(mockUserService.findMe).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
+      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findRoomMemberCount).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+      );
+      expect(mockRoomRepository.increaseCurrentMembersCount).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+      );
+      expect(mockRoomMemberService.joinRoom).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+        mockUserSummary.id,
+      );
+    });
+
+    it('존재하지 않는 방에 참여하면 NotFoundException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(null);
+
+      await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockRoomRepository.findParticipatingRoom).not.toHaveBeenCalled();
+    });
+
+    it('이미 참여 중이면 BadRequestException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce({ id: 123 });
+
+      await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockRoomMemberService.findRoomMemberCount).not.toHaveBeenCalled();
+    });
+
+    it('정원이 가득 찼으면 BadRequestException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(
+        mockRoomEntity.maxMembersCount,
+      );
+
+      await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockRoomRepository.increaseCurrentMembersCount).not.toHaveBeenCalled();
+    });
+
+    it('사용자 정보가 방 조건에 맞지 않으면 BadRequestException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce({
+        ...mockCurrentUser,
+        gender: 'FEMALE',
+      });
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+
+      await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('leaveRoom', () => {
+    it('일반 멤버가 방을 나가면 멤버 수를 줄이고 멤버를 삭제', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(true);
+      mockRoomRepository.decreaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.leaveRoom.mockResolvedValueOnce({ affected: 1 });
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(1);
+
+      await roomService.leaveRoom(mockRoomEntity.id, mockUserSummary.id + 1);
+
+      expect(mockRoomRepository.decreaseCurrentMembersCount).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+      );
+      expect(mockRoomMemberService.leaveRoom).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+        mockUserSummary.id + 1,
+      );
+      expect(mockRoomRepository.updateRoomHostUser).not.toHaveBeenCalled();
+    });
+
+    it('방장이 나가면 처음 들어왔던 일반 참여자를 새 방장으로 변경', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(true);
+      mockRoomRepository.decreaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.leaveRoom.mockResolvedValueOnce({ affected: 1 });
+      mockRoomMemberService.findFirstJoinedMemberId.mockResolvedValueOnce(2);
+      mockRoomRepository.updateRoomHostUser.mockResolvedValueOnce({ affected: 1 });
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(1);
+
+      await roomService.leaveRoom(mockRoomEntity.id, mockUserSummary.id);
+
+      expect(mockRoomMemberService.findFirstJoinedMemberId).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+        mockUserSummary.id,
+      );
+      expect(mockRoomRepository.updateRoomHostUser).toHaveBeenCalledWith(mockManager, 1, 2);
+    });
+
+    it('마지막 멤버가 나가면 방을 삭제', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(true);
+      mockRoomRepository.decreaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.leaveRoom.mockResolvedValueOnce({ affected: 1 });
+      mockRoomMemberService.findFirstJoinedMemberId.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(0);
+      mockRoomRepository.deleteRoom.mockResolvedValueOnce({ raw: [], affected: 1 });
+
+      await roomService.leaveRoom(mockRoomEntity.id, mockUserSummary.id);
+
+      expect(mockRoomRepository.deleteRoom).toHaveBeenCalledWith(mockRoomEntity.id, mockManager);
+    });
+
+    it('참여하지 않은 사용자가 나가기를 요청하면 BadRequestException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(false);
+
+      await expect(roomService.leaveRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/rooms/roomMember.repository.ts
+++ b/src/rooms/roomMember.repository.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { RoomMember } from './entities/room-member.entity';
+import { EntityManager, Not, Repository } from 'typeorm';
+
+@Injectable()
+export class RoomMemberRepository {
+  constructor(
+    @InjectRepository(RoomMember)
+    private readonly roomMemberRepository: Repository<RoomMember>,
+  ) {}
+
+  async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {
+    return await manager.count(RoomMember, {
+      where: {
+        room: { id: roomId },
+      },
+    });
+  }
+
+  async isRoomMember(roomId: number, userId: number): Promise<boolean> {
+    return await this.roomMemberRepository.exists({
+      where: {
+        room: { id: roomId },
+        user: { id: userId },
+      },
+    });
+  }
+
+  async joinRoom(manager: EntityManager, roomId: number, userId: number) {
+    return await manager.save(RoomMember, {
+      room: { id: roomId },
+      user: { id: userId },
+    });
+  }
+
+  async leaveRoom(manager: EntityManager, roomId: number, userId: number) {
+    return await manager.delete(RoomMember, {
+      room: { id: roomId },
+      user: { id: userId },
+    });
+  }
+
+  async findFirstJoinedMember(manager: EntityManager, roomId: number, userId: number) {
+    return await manager.findOne(RoomMember, {
+      where: {
+        room: { id: roomId },
+        user: { id: Not(userId) },
+      },
+      relations: { user: true },
+      order: {
+        id: 'ASC',
+      },
+    });
+  }
+}

--- a/src/rooms/roomMember.service.ts
+++ b/src/rooms/roomMember.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { RoomMemberRepository } from './roomMember.repository';
+import { EntityManager } from 'typeorm';
+
+@Injectable()
+export class RoomMemberService {
+  constructor(private readonly roomMemberRepository: RoomMemberRepository) {}
+
+  async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {
+    return await this.roomMemberRepository.findRoomMemberCount(manager, roomId);
+  }
+  async joinRoom(manager: EntityManager, roomId: number, userId: number) {
+    return await this.roomMemberRepository.joinRoom(manager, roomId, userId);
+  }
+
+  async leaveRoom(manager: EntityManager, roomId: number, userId: number) {
+    return await this.roomMemberRepository.leaveRoom(manager, roomId, userId);
+  }
+
+  async isRoomMember(roomId: number, userId: number): Promise<boolean> {
+    return await this.roomMemberRepository.isRoomMember(roomId, userId);
+  }
+
+  async findFirstJoinedMemberId(manager: EntityManager, roomId: number, userId: number) {
+    const hostUser = await this.roomMemberRepository.findFirstJoinedMember(manager, roomId, userId);
+    return hostUser?.user.id;
+  }
+}

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -37,6 +37,7 @@ import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
+import { RoomMember } from './entities/room-member.entity';
 
 @ApiTags('Room')
 @ApiExtraModels(ResponseRoomListDto, ResponseRoomDetailDto)
@@ -126,5 +127,42 @@ export class RoomController {
     @CurrentUser() user: AuthenticatedUser,
   ) {
     await this.roomService.deleteRoom(roomId, user.userId);
+  }
+
+  @Post(':id/join')
+  @Authenticated()
+  @HttpCode(201)
+  @ApiOperation({ summary: '방 참여' })
+  @ApiParam({ name: 'id', description: '참여할 방 ID', type: Number })
+  @ApiCreatedResponse({ description: '방 참여 성공' })
+  @ApiBadRequestResponse({
+    description: '이미 참여 중이거나, 방 상태/정원/방 조건에 맞지 않는 경우',
+  })
+  @ApiNotFoundResponse({ description: '존재하지 않는 방에 참여하려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async joinRoom(
+    @Param('id', ParseIntPipe) roomId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<RoomMember> {
+    return await this.roomService.joinRoom(roomId, user.userId);
+  }
+
+  @Delete(':id/leave')
+  @Authenticated()
+  @HttpCode(204)
+  @ApiOperation({
+    summary: '방 나가기',
+    description: '참여 중인 방에서 나가며, 성공 시 응답 본문 없이 204 No Content를 반환',
+  })
+  @ApiParam({ name: 'id', description: '나갈 방 ID', type: Number })
+  @ApiNoContentResponse({ description: '방 나가기 성공, 응답 본문은 반환되지 않음' })
+  @ApiBadRequestResponse({ description: '해당 방에 참여하지 않은 사용자인 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 방에서 나가려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async leaveRoom(
+    @Param('id', ParseIntPipe) roomId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    await this.roomService.leaveRoom(roomId, user.userId);
   }
 }

--- a/src/rooms/rooms.module.ts
+++ b/src/rooms/rooms.module.ts
@@ -5,10 +5,22 @@ import { RoomMember } from './entities/room-member.entity';
 import { RoomController } from './rooms.controller';
 import { RoomService } from './rooms.service';
 import { RoomRepository } from './room.repository';
+import { RoomMemberRepository } from './roomMember.repository';
+import { UserService } from 'src/users/users.service';
+import { User } from 'src/users/entities/user.entity';
+import { UserRepository } from 'src/users/users.repository';
+import { RoomMemberService } from './roomMember.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Room, RoomMember])],
+  imports: [TypeOrmModule.forFeature([Room, RoomMember, User])],
   controllers: [RoomController],
-  providers: [RoomService, RoomRepository],
+  providers: [
+    RoomService,
+    RoomRepository,
+    RoomMemberService,
+    RoomMemberRepository,
+    UserService,
+    UserRepository,
+  ],
 })
 export class RoomModule {}

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -1,3 +1,4 @@
+import { RoomMemberService } from './roomMember.service';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { RoomRepository } from './room.repository';
 import {
@@ -6,7 +7,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import dayjs from 'dayjs';
 import {
   ResponseOpenRoomsCountDto,
@@ -17,19 +18,25 @@ import { RoomMapper } from './mappers/room.mapper';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { PAGINATION_CONSTANTS } from './constants/room.constant';
 import { UpdateRoomDto } from './dto/update-room.dto';
+import { UserService } from 'src/users/users.service';
+import { Room, RoomStatus, RoomType } from './entities/room.entity';
+import { calculateAge } from 'src/commons/utils/age.util';
+import { RoomMember } from './entities/room-member.entity';
+import { MeUserResponseDto } from 'src/users/dto/me-user-response.dto';
 
 @Injectable()
 export class RoomService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly roomRepository: RoomRepository,
+    private readonly roomMemberService: RoomMemberService,
+    private readonly userService: UserService,
   ) {}
 
   async createRoom(userId: number, createRoomDto: CreateRoomDto): Promise<ResponseRoomDetailDto> {
-    const participatingRoom = await this.roomRepository.findParticipatingRoom(userId);
-    if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
+    await this.validateParticipatingRoom(userId);
 
-    this.validationProperty(createRoomDto);
+    this.validateRoomProperties(createRoomDto);
 
     const newRoomId = await this.dataSource.transaction(async (manager) => {
       const newRoom = await this.roomRepository.createRoom(manager, userId, createRoomDto);
@@ -67,9 +74,7 @@ export class RoomService {
   }
 
   async findRoomById(roomId: number): Promise<ResponseRoomDetailDto> {
-    const room = await this.roomRepository.findRoomById(roomId);
-
-    if (!room) throw new NotFoundException(`존재하지 않는 방입니다.`);
+    const room = await this.findExistingRoomOrThrow(roomId);
 
     return RoomMapper.toDetailDto(room);
   }
@@ -87,8 +92,7 @@ export class RoomService {
     updateRoomDto: UpdateRoomDto,
     userId: number,
   ): Promise<ResponseRoomDetailDto> {
-    const existingRoom = await this.roomRepository.findRoomById(roomId);
-    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
+    const existingRoom = await this.findExistingRoomOrThrow(roomId);
 
     if (existingRoom.hostUser.id !== userId)
       throw new ForbiddenException('방장만 방을 수정할 수 있습니다.');
@@ -100,14 +104,14 @@ export class RoomService {
       maxAge: updateRoomDto.maxAge ?? existingRoom.maxAge,
       lunchAt: updateRoomDto.lunchAt ?? existingRoom.lunchAt,
     };
-    this.validationProperty(mergeRoomForValidation);
+    this.validateRoomProperties(mergeRoomForValidation);
 
     await this.roomRepository.updateRoom(roomId, updateRoomDto);
 
     return await this.findRoomById(roomId);
   }
 
-  validationProperty(dto: { minAge?: number; maxAge?: number; lunchAt?: string }): void {
+  validateRoomProperties(dto: { minAge?: number; maxAge?: number; lunchAt?: string }): void {
     if (dto.minAge !== undefined && dto.maxAge !== undefined && dto.minAge > dto.maxAge)
       throw new BadRequestException('최소 나이와 최대 나이 옵션이 올바르지 않습니다.');
 
@@ -115,14 +119,97 @@ export class RoomService {
       throw new BadRequestException('lunchAt은 현재보다 미래여야 합니다.');
   }
 
-  async deleteRoom(roomId: number, userId: number) {
-    const existingRoom = await this.roomRepository.findRoomById(roomId);
-    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
+  async deleteRoom(roomId: number, userId: number): Promise<void> {
+    const existingRoom = await this.findExistingRoomOrThrow(roomId);
 
     if (existingRoom.hostUser.id !== userId)
       throw new ForbiddenException('방장만 방을 삭제할 수 있습니다.');
 
     const deletedRoom = await this.roomRepository.deleteRoom(roomId);
     if (!deletedRoom.affected) throw new NotFoundException('존재하지 않는 방입니다.');
+  }
+
+  async joinRoom(roomId: number, userId: number): Promise<RoomMember> {
+    const currentUser = await this.userService.findMe(userId);
+    const existingRoom = await this.findExistingRoomOrThrow(roomId);
+
+    await this.validateParticipatingRoom(userId);
+
+    this.validateJoinRoom(existingRoom, currentUser);
+
+    return await this.joinRoomTransaction(existingRoom, userId);
+  }
+
+  async joinRoomTransaction(room: Room, userId: number): Promise<RoomMember> {
+    return await this.dataSource.transaction(async (manager) => {
+      const memberCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
+      if (room.maxMembersCount <= memberCount)
+        throw new BadRequestException('방 인원이 가득 차 참여할 수 없습니다.');
+
+      await this.roomRepository.increaseCurrentMembersCount(manager, room.id);
+      return await this.roomMemberService.joinRoom(manager, room.id, userId);
+    });
+  }
+
+  validateJoinRoom(room: Room, user: MeUserResponseDto): void {
+    if (room.status !== RoomStatus.OPEN) throw new BadRequestException('입장할 수 없는 방입니다.');
+
+    const roomTypeByGender = {
+      MALE: RoomType.MALE,
+      FEMALE: RoomType.FEMALE,
+    };
+    const userAge = calculateAge(user.birthDate);
+    if (
+      (room.roomType !== RoomType.ANY && room.roomType !== roomTypeByGender[user.gender]) ||
+      room.minAge > userAge ||
+      room.maxAge < userAge
+    )
+      throw new BadRequestException('사용자 정보가 방 조건에 맞지 않습니다.');
+  }
+
+  async leaveRoom(roomId: number, userId: number): Promise<void> {
+    const existingRoom = await this.findExistingRoomOrThrow(roomId);
+
+    const isRoomMember = await this.roomMemberService.isRoomMember(roomId, userId);
+    if (!isRoomMember) throw new BadRequestException('해당 방에 참여하지 않은 사용자입니다.');
+
+    await this.leaveRoomTransaction(existingRoom, userId);
+  }
+
+  async leaveRoomTransaction(room: Room, userId: number): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      await this.roomRepository.decreaseCurrentMembersCount(manager, room.id);
+      await this.roomMemberService.leaveRoom(manager, room.id, userId);
+
+      await this.updateHostUser(manager, room, userId);
+
+      const roomMembersCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
+      if (roomMembersCount < 1) await this.roomRepository.deleteRoom(room.id, manager);
+    });
+  }
+
+  async updateHostUser(manager: EntityManager, room: Room, userId: number): Promise<void> {
+    if (room.hostUser.id === userId) {
+      const newHostUserId = await this.roomMemberService.findFirstJoinedMemberId(
+        manager,
+        room.id,
+        userId,
+      );
+
+      if (newHostUserId)
+        await this.roomRepository.updateRoomHostUser(manager, room.id, newHostUserId);
+    }
+  }
+
+  async findExistingRoomOrThrow(roomId: number): Promise<Room> {
+    const existingRoom = await this.roomRepository.findRoomById(roomId);
+    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
+
+    return existingRoom;
+  }
+
+  async validateParticipatingRoom(userId: number): Promise<void> {
+    const participatingRoom = await this.roomRepository.findParticipatingRoom(userId);
+    if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
   }
 }

--- a/test/rooms-join-leave.e2e-spec.ts
+++ b/test/rooms-join-leave.e2e-spec.ts
@@ -1,0 +1,154 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { Room } from '../src/rooms/entities/room.entity';
+import { RoomMember } from '../src/rooms/entities/room-member.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+import { clearRoomTables, createRoomFixture, signupUser } from './rooms.e2e-helper';
+
+jest.setTimeout(30000);
+
+describe('Rooms Join/Leave (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+  const httpApp = () => app.getHttpServer();
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await clearRoomTables(dataSource);
+  });
+
+  it('POST /rooms/:id/join 사용자가 방에 참여', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host@gmail.com', '방장');
+    const guestSignupResponse = await signupUser(httpApp, 'user@gmail.com', '참여유저');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      title: '참여 테스트 방',
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    const response = await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(201);
+
+    const joinedRoom = await dataSource.getRepository(Room).findOneByOrFail({
+      id: room.id,
+    });
+    const roomMembersCount = await dataSource.getRepository(RoomMember).count({
+      where: {
+        room: { id: room.id },
+      },
+    });
+    const joinedMember = await dataSource.getRepository(RoomMember).findOne({
+      where: {
+        room: { id: room.id },
+        user: { id: guestSignupResponse.body.user.id },
+      },
+    });
+
+    expect(joinedRoom.currentMembersCount).toBe(2);
+    expect(roomMembersCount).toBe(2);
+    expect(joinedMember).not.toBeNull();
+  });
+
+  it('POST /rooms/:id/join 이미 참여 중이면 실패', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host@gmail.com', '중복방장');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser);
+
+    const response = await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${hostSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('이미 참여 중인 방이 있습니다.');
+  });
+
+  it('DELETE /rooms/:id/leave 참여 중인 사용자가 방에서 나감', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host@gmail.com', '나가기방장');
+    const guestSignupResponse = await signupUser(httpApp, 'user@gmail.com', '나가기유저');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/leave`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(204);
+
+    const leftRoom = await dataSource.getRepository(Room).findOneByOrFail({
+      id: room.id,
+    });
+    const leftMember = await dataSource.getRepository(RoomMember).findOne({
+      where: {
+        room: { id: room.id },
+        user: { id: guestSignupResponse.body.user.id },
+      },
+    });
+
+    expect(leftRoom.currentMembersCount).toBe(1);
+    expect(leftMember).toBeNull();
+  });
+
+  it('DELETE /rooms/:id/leave 방장이 나가면 다음 멤버에게 방장이 위임', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host@gmail.com', '기존방장');
+    const guestSignupResponse = await signupUser(httpApp, 'user@gmail.com', '다음방장');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser);
+    await dataSource.getRepository(Room).update(room.id, {
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/leave`)
+      .set('Authorization', `Bearer ${hostSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(204);
+
+    const updatedRoom = await dataSource.getRepository(Room).findOne({
+      where: { id: room.id },
+      relations: {
+        hostUser: true,
+      },
+    });
+
+    expect(updatedRoom).not.toBeNull();
+    expect(updatedRoom?.hostUser.id).toBe(guestSignupResponse.body.user.id);
+    expect(updatedRoom?.currentMembersCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## 연관된 이슈

- #81

## 📝 작업 내용

- [x] `POST /rooms/:id/join` 방 참여 API 구현
- [x] `DELETE /rooms/:id/leave` 방 나가기 API 구현
- [x] `RoomController`에 방 참여/나가기 엔드포인트 추가
- [x] 로그인 사용자 기반 방 참여/나가기 로직 연결
- [x] 방 참여/나가기 Swagger 문서화 추가
- [x] 방 존재 여부 검증 추가
- [x] 이미 참여 중인 사용자인지 검증 추가
- [x] 방 상태가 `OPEN`인지 검증 추가
- [x] 방 정원 초과 여부 검증 추가
- [x] 사용자와 방 조건 검증 추가
- [x] 생년월일 기반 나이 계산 유틸 추가
- [x] 방 참여 시 `RoomMember` 생성 로직 구현
- [x] 방 참여 시 `currentMembersCount` 증가 처리 추가
- [x] 방 나가기 시 `RoomMember` 삭제 로직 구현
- [x] 방 나가기 시 `currentMembersCount` 감소 처리 추가
- [x] 방장이 나갈 때 다음 참여자에게 방장 위임 로직 추가
- [x] 마지막 멤버가 나갈 때 방 삭제 처리 추가
- [x] 방장 변경을 위한 `hostUserId` 컬럼 반영
- [x] 방 참여/나가기 `RoomService` 테스트 추가
- [x] 방 참여/나가기 e2e 테스트 추가
