### PR TITLE
방 강제퇴장 API 구현

### DIFF
--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -61,8 +61,8 @@ export class RoomRepository {
     });
   }
 
-  async findRoomById(roomId: number): Promise<Room | null> {
-    return await this.roomRepository.findOne({
+  async findRoomById(roomId: number, manager?: EntityManager): Promise<Room | null> {
+    const queryOptions = {
       where: { id: roomId },
       relations: {
         hostUser: true,
@@ -70,7 +70,11 @@ export class RoomRepository {
           user: true,
         },
       },
-    });
+    };
+
+    if (manager) return await manager.findOne(Room, queryOptions);
+
+    return await this.roomRepository.findOne(queryOptions);
   }
 
   async findRooms(query: FindRoomsQueryDto): Promise<Room[]> {

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -32,6 +32,7 @@ const mockRoomEntity = {
   place: '학식당 앞',
   lunchAt: '2099-03-27T03:30:00.000Z',
   createdAt: '2026-03-27T06:26:40.062Z',
+  hostUserId: mockUserSummary.id,
   hostUser: mockUserSummary,
   roomMembers: [
     {
@@ -724,6 +725,60 @@ describe('RoomService', () => {
       );
 
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('kickRoomMember', () => {
+    it('방장이 일반 멤버를 강제 퇴장시키면 멤버 수를 줄이고 멤버를 삭제', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(true);
+      mockRoomRepository.decreaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.leaveRoom.mockResolvedValueOnce({ affected: 1 });
+
+      await roomService.kickRoomMember(mockRoomEntity.id, 2, mockUserSummary.id);
+
+      expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id, mockManager);
+      expect(mockRoomMemberService.isRoomMember).toHaveBeenCalledWith(
+        mockRoomEntity.id,
+        2,
+        mockManager,
+      );
+      expect(mockRoomRepository.decreaseCurrentMembersCount).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+      );
+      expect(mockRoomMemberService.leaveRoom).toHaveBeenCalledWith(mockManager, mockRoomEntity.id, 2);
+    });
+
+    it('방장이 아닌 사용자가 강제 퇴장시키면 ForbiddenException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+
+      await expect(roomService.kickRoomMember(mockRoomEntity.id, 2, 999)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockRoomRepository.decreaseCurrentMembersCount).not.toHaveBeenCalled();
+    });
+
+    it('자기 자신을 강제 퇴장시키려 하면 BadRequestException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+
+      await expect(
+        roomService.kickRoomMember(mockRoomEntity.id, mockUserSummary.id, mockUserSummary.id),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRoomMemberService.isRoomMember).not.toHaveBeenCalled();
+    });
+
+    it('참여 중이지 않은 사용자를 강제 퇴장시키려 하면 BadRequestException을 반환', async () => {
+      mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
+      mockRoomMemberService.isRoomMember.mockResolvedValueOnce(false);
+
+      await expect(roomService.kickRoomMember(mockRoomEntity.id, 2, mockUserSummary.id)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockRoomRepository.decreaseCurrentMembersCount).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/rooms/roomMember.repository.ts
+++ b/src/rooms/roomMember.repository.ts
@@ -10,6 +10,12 @@ export class RoomMemberRepository {
     private readonly roomMemberRepository: Repository<RoomMember>,
   ) {}
 
+  async findRoomMembersById(roomid: number): Promise<RoomMember[]> {
+    return await this.roomMemberRepository.find({
+      where: { room: { id: roomid } },
+    });
+  }
+
   async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {
     return await manager.count(RoomMember, {
       where: {
@@ -18,13 +24,17 @@ export class RoomMemberRepository {
     });
   }
 
-  async isRoomMember(roomId: number, userId: number): Promise<boolean> {
-    return await this.roomMemberRepository.exists({
+  async isRoomMember(roomId: number, userId: number, manager?: EntityManager): Promise<boolean> {
+    const queryOptions = {
       where: {
         room: { id: roomId },
         user: { id: userId },
       },
-    });
+    };
+
+    if (manager) return await manager.exists(RoomMember, queryOptions);
+
+    return await this.roomMemberRepository.exists(queryOptions);
   }
 
   async joinRoom(manager: EntityManager, roomId: number, userId: number) {

--- a/src/rooms/roomMember.service.ts
+++ b/src/rooms/roomMember.service.ts
@@ -1,14 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { RoomMemberRepository } from './roomMember.repository';
 import { EntityManager } from 'typeorm';
+import { RoomMember } from './entities/room-member.entity';
 
 @Injectable()
 export class RoomMemberService {
   constructor(private readonly roomMemberRepository: RoomMemberRepository) {}
 
+  async findRoomMembersById(roomId: number): Promise<RoomMember[]> {
+    return await this.roomMemberRepository.findRoomMembersById(roomId);
+  }
+
   async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {
     return await this.roomMemberRepository.findRoomMemberCount(manager, roomId);
   }
+
   async joinRoom(manager: EntityManager, roomId: number, userId: number) {
     return await this.roomMemberRepository.joinRoom(manager, roomId, userId);
   }
@@ -17,8 +23,8 @@ export class RoomMemberService {
     return await this.roomMemberRepository.leaveRoom(manager, roomId, userId);
   }
 
-  async isRoomMember(roomId: number, userId: number): Promise<boolean> {
-    return await this.roomMemberRepository.isRoomMember(roomId, userId);
+  async isRoomMember(roomId: number, userId: number, manager?: EntityManager): Promise<boolean> {
+    return await this.roomMemberRepository.isRoomMember(roomId, userId, manager);
   }
 
   async findFirstJoinedMemberId(manager: EntityManager, roomId: number, userId: number) {

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -165,4 +165,29 @@ export class RoomController {
   ) {
     await this.roomService.leaveRoom(roomId, user.userId);
   }
+
+  @Delete('/:roomId/members/:userId')
+  @Authenticated()
+  @HttpCode(204)
+  @ApiOperation({
+    summary: '방 멤버 강제 퇴장',
+    description:
+      '방장만 다른 참여자를 강제 퇴장시킬 수 있으며, 성공 시 응답 본문 없이 204 No Content를 반환',
+  })
+  @ApiParam({ name: 'roomId', description: '강제 퇴장할 방 ID', type: Number })
+  @ApiParam({ name: 'userId', description: '강제 퇴장할 사용자 ID', type: Number })
+  @ApiNoContentResponse({ description: '강제 퇴장 성공, 응답 본문은 반환되지 않음' })
+  @ApiBadRequestResponse({
+    description: '대상 사용자가 방에 없거나, 방장/자기 자신을 강제 퇴장시키려는 경우',
+  })
+  @ApiForbiddenResponse({ description: '방장이 아닌 사용자가 강제 퇴장을 시도한 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 방에서 강제 퇴장을 시도한 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async kickRoomMember(
+    @Param('roomId', ParseIntPipe) roomId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    await this.roomService.kickRoomMember(roomId, userId, user.userId);
+  }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -111,14 +111,6 @@ export class RoomService {
     return await this.findRoomById(roomId);
   }
 
-  validateRoomProperties(dto: { minAge?: number; maxAge?: number; lunchAt?: string }): void {
-    if (dto.minAge !== undefined && dto.maxAge !== undefined && dto.minAge > dto.maxAge)
-      throw new BadRequestException('최소 나이와 최대 나이 옵션이 올바르지 않습니다.');
-
-    if (dto.lunchAt && dayjs(dto.lunchAt).isBefore(dayjs()))
-      throw new BadRequestException('lunchAt은 현재보다 미래여야 합니다.');
-  }
-
   async deleteRoom(roomId: number, userId: number): Promise<void> {
     const existingRoom = await this.findExistingRoomOrThrow(roomId);
 
@@ -140,6 +132,21 @@ export class RoomService {
     return await this.joinRoomTransaction(existingRoom, userId);
   }
 
+  async leaveRoom(roomId: number, userId: number): Promise<void> {
+    const existingRoom = await this.findExistingRoomOrThrow(roomId);
+
+    await this.validateExistingRoomMember(roomId, userId);
+
+    await this.leaveRoomTransaction(existingRoom, userId);
+  }
+
+  async kickRoomMember(roomId: number, targetUserId: number, currentUserId: number): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      await this.validateKickRoomMember(manager, roomId, targetUserId, currentUserId);
+      await this.leaveRoomAndDecreaseMemberCount(manager, roomId, targetUserId);
+    });
+  }
+
   async joinRoomTransaction(room: Room, userId: number): Promise<RoomMember> {
     return await this.dataSource.transaction(async (manager) => {
       const memberCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
@@ -149,6 +156,66 @@ export class RoomService {
       await this.roomRepository.increaseCurrentMembersCount(manager, room.id);
       return await this.roomMemberService.joinRoom(manager, room.id, userId);
     });
+  }
+
+  async leaveRoomTransaction(room: Room, userId: number): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      await this.leaveRoomAndDecreaseMemberCount(manager, room.id, userId);
+
+      await this.updateHostUser(manager, room, userId);
+
+      const roomMembersCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
+      if (roomMembersCount < 1) await this.roomRepository.deleteRoom(room.id, manager);
+    });
+  }
+
+  async leaveRoomAndDecreaseMemberCount(
+    manager: EntityManager,
+    roomId: number,
+    userId: number,
+  ): Promise<void> {
+    await this.roomRepository.decreaseCurrentMembersCount(manager, roomId);
+    await this.roomMemberService.leaveRoom(manager, roomId, userId);
+  }
+
+  async updateHostUser(manager: EntityManager, room: Room, userId: number): Promise<void> {
+    if (room.hostUser.id === userId) {
+      const newHostUserId = await this.roomMemberService.findFirstJoinedMemberId(
+        manager,
+        room.id,
+        userId,
+      );
+
+      if (newHostUserId)
+        await this.roomRepository.updateRoomHostUser(manager, room.id, newHostUserId);
+    }
+  }
+
+  validateRoomProperties(dto: { minAge?: number; maxAge?: number; lunchAt?: string }): void {
+    if (dto.minAge !== undefined && dto.maxAge !== undefined && dto.minAge > dto.maxAge)
+      throw new BadRequestException('최소 나이와 최대 나이 옵션이 올바르지 않습니다.');
+
+    if (dto.lunchAt && dayjs(dto.lunchAt).isBefore(dayjs()))
+      throw new BadRequestException('lunchAt은 현재보다 미래여야 합니다.');
+  }
+
+  async validateKickRoomMember(
+    manager: EntityManager,
+    roomId: number,
+    targetUserId: number,
+    currentUserId: number,
+  ): Promise<void> {
+    const currentRoom = await this.findExistingRoomOrThrow(roomId, manager);
+    if (currentRoom.hostUserId !== currentUserId)
+      throw new ForbiddenException('강제퇴장은 방장만 할 수 있습니다.');
+
+    if (targetUserId === currentUserId)
+      throw new BadRequestException('자기 자신을 강제퇴장 시킬 수 없습니다.');
+
+    if (targetUserId === currentRoom.hostUserId)
+      throw new BadRequestException('방장은 강제퇴장 시킬 수 없습니다.');
+
+    await this.validateExistingRoomMember(currentRoom.id, targetUserId, manager);
   }
 
   validateJoinRoom(room: Room, user: MeUserResponseDto): void {
@@ -167,49 +234,27 @@ export class RoomService {
       throw new BadRequestException('사용자 정보가 방 조건에 맞지 않습니다.');
   }
 
-  async leaveRoom(roomId: number, userId: number): Promise<void> {
-    const existingRoom = await this.findExistingRoomOrThrow(roomId);
-
-    const isRoomMember = await this.roomMemberService.isRoomMember(roomId, userId);
-    if (!isRoomMember) throw new BadRequestException('해당 방에 참여하지 않은 사용자입니다.');
-
-    await this.leaveRoomTransaction(existingRoom, userId);
-  }
-
-  async leaveRoomTransaction(room: Room, userId: number): Promise<void> {
-    await this.dataSource.transaction(async (manager) => {
-      await this.roomRepository.decreaseCurrentMembersCount(manager, room.id);
-      await this.roomMemberService.leaveRoom(manager, room.id, userId);
-
-      await this.updateHostUser(manager, room, userId);
-
-      const roomMembersCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
-      if (roomMembersCount < 1) await this.roomRepository.deleteRoom(room.id, manager);
-    });
-  }
-
-  async updateHostUser(manager: EntityManager, room: Room, userId: number): Promise<void> {
-    if (room.hostUser.id === userId) {
-      const newHostUserId = await this.roomMemberService.findFirstJoinedMemberId(
-        manager,
-        room.id,
-        userId,
-      );
-
-      if (newHostUserId)
-        await this.roomRepository.updateRoomHostUser(manager, room.id, newHostUserId);
-    }
-  }
-
-  async findExistingRoomOrThrow(roomId: number): Promise<Room> {
-    const existingRoom = await this.roomRepository.findRoomById(roomId);
-    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
-
-    return existingRoom;
-  }
-
   async validateParticipatingRoom(userId: number): Promise<void> {
     const participatingRoom = await this.roomRepository.findParticipatingRoom(userId);
     if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
+  }
+
+  async validateExistingRoomMember(
+    roomId: number,
+    userId: number,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const isRoomMember = await this.roomMemberService.isRoomMember(roomId, userId, manager);
+    if (!isRoomMember) throw new BadRequestException('현재 방에 참여중인 사용자가 아닙니다.');
+  }
+
+  async findExistingRoomOrThrow(roomId: number, manager?: EntityManager): Promise<Room> {
+    const existingRoom = manager
+      ? await this.roomRepository.findRoomById(roomId, manager)
+      : await this.roomRepository.findRoomById(roomId);
+
+    if (!existingRoom) throw new NotFoundException('존재하지 않는 방입니다.');
+
+    return existingRoom;
   }
 }

--- a/test/rooms-join-leave.e2e-spec.ts
+++ b/test/rooms-join-leave.e2e-spec.ts
@@ -151,4 +151,108 @@ describe('Rooms Join/Leave (e2e)', () => {
     expect(updatedRoom?.hostUser.id).toBe(guestSignupResponse.body.user.id);
     expect(updatedRoom?.currentMembersCount).toBe(1);
   });
+
+  it('DELETE /rooms/:roomId/members/:userId 방장이 일반 멤버를 강제 퇴장', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host-kick@gmail.com', '강퇴방장');
+    const guestSignupResponse = await signupUser(httpApp, 'user-kick@gmail.com', '강퇴대상');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/members/${guestSignupResponse.body.user.id}`)
+      .set('Authorization', `Bearer ${hostSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(204);
+
+    const updatedRoom = await dataSource.getRepository(Room).findOneByOrFail({
+      id: room.id,
+    });
+    const kickedMember = await dataSource.getRepository(RoomMember).findOne({
+      where: {
+        room: { id: room.id },
+        user: { id: guestSignupResponse.body.user.id },
+      },
+    });
+
+    expect(updatedRoom.currentMembersCount).toBe(1);
+    expect(kickedMember).toBeNull();
+  });
+
+  it('DELETE /rooms/:roomId/members/:userId 방장이 아닌 사용자가 강제 퇴장시키면 실패', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host-kick-forbidden@gmail.com', '방장');
+    const guestSignupResponse = await signupUser(
+      httpApp,
+      'user-kick-forbidden@gmail.com',
+      '참여자',
+    );
+    const otherSignupResponse = await signupUser(
+      httpApp,
+      'other-kick-forbidden@gmail.com',
+      '일반유저',
+    );
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser, {
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    await request(httpApp())
+      .post(`/rooms/${room.id}/join`)
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/members/${guestSignupResponse.body.user.id}`)
+      .set('Authorization', `Bearer ${otherSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe('강제퇴장은 방장만 할 수 있습니다.');
+  });
+
+  it('DELETE /rooms/:roomId/members/:userId 자기 자신을 강제 퇴장시키려 하면 실패', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host-kick-self@gmail.com', '방장본인');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/members/${hostSignupResponse.body.user.id}`)
+      .set('Authorization', `Bearer ${hostSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('자기 자신을 강제퇴장 시킬 수 없습니다.');
+  });
+
+  it('DELETE /rooms/:roomId/members/:userId 참여하지 않은 사용자를 강제 퇴장시키려 하면 실패', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'host-kick-missing@gmail.com', '방장');
+    const guestSignupResponse = await signupUser(
+      httpApp,
+      'user-kick-missing@gmail.com',
+      '미참여유저',
+    );
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+    const room = await createRoomFixture(dataSource, hostUser);
+
+    const response = await request(httpApp())
+      .delete(`/rooms/${room.id}/members/${guestSignupResponse.body.user.id}`)
+      .set('Authorization', `Bearer ${hostSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('현재 방에 참여중인 사용자가 아닙니다.');
+  });
 });


### PR DESCRIPTION
## 연관된 이슈

- #83 

## 📝 작업 내용

- [x] `DELETE /rooms/:roomId/members/:userId` 강제 퇴장 API 구현
- [x] `RoomController`에 강제 퇴장 엔드포인트 추가
- [x] 로그인 사용자 기반 강제 퇴장 로직 연결
- [x] 강제 퇴장 Swagger 문서화 추가
- [x] 방 존재 여부 검증 추가
- [x] 방장만 강제 퇴장 가능하도록 권한 검증 추가
- [x] 자기 자신 강제 퇴장 예외 처리 추가
- [x] 방장 대상 강제 퇴장 예외 처리 추가
- [x] 대상 사용자가 해당 방에 참여 중인지 검증 추가
- [x] 강제 퇴장 트랜잭션 처리 추가
- [x] 강제 퇴장 시 멤버 삭제 후 방 인원 수 감소 로직 작성
- [x] `RoomService` 강제 퇴장 테스트 추가
- [x] 강제 퇴장 e2e 테스트 추가
- [x] `RoomService` 함수 순서 가독성 기준으로 재정리
