### PR TITLE
MealMenu Controller 응답 매핑 경계 재정리

### DIFF
--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -6,8 +6,11 @@ import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
 import { GetMealMenuRankingQueryDto } from './dto/get-meal-menu-ranking-query.dto';
 import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
+import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
 import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
 import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.dto';
+import { ActionType } from './entities/meal-menu-reaction.entity';
+import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenusService } from './meal-menus.service';
 
 @ApiTags('MealMenu')
@@ -19,7 +22,8 @@ export class MealMenusController {
   @ApiOperation({ summary: '학식 목록 조회' })
   @ApiOkResponse({ type: MealMenuListResponseDto })
   async findMealMenus(@Query() query: GetMealMenuListQueryDto): Promise<MealMenuListResponseDto> {
-    return this.mealMenusService.findMealMenus(query);
+    const mealMenus = await this.mealMenusService.findMealMenus(query);
+    return this.toListResponse(mealMenus);
   }
 
   @Get('rankings')
@@ -28,7 +32,8 @@ export class MealMenusController {
   async findMealMenuRankings(
     @Query() query: GetMealMenuRankingQueryDto,
   ): Promise<MealMenuListResponseDto> {
-    return this.mealMenusService.findMealMenuRankings(query);
+    const mealMenus = await this.mealMenusService.findMealMenuRankings(query);
+    return this.toListResponse(mealMenus);
   }
 
   @Get(':mealMenuId')
@@ -37,7 +42,8 @@ export class MealMenusController {
   async findMealMenuById(
     @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
   ): Promise<MealMenuDetailResponseDto> {
-    return this.mealMenusService.findMealMenuById(mealMenuId);
+    const mealMenu = await this.mealMenusService.findMealMenuById(mealMenuId);
+    return this.toDetailResponse(mealMenu);
   }
 
   @Post(':mealMenuId/like')
@@ -49,7 +55,8 @@ export class MealMenusController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
   ): Promise<MealMenuReactionResponseDto> {
-    return this.mealMenusService.likeMealMenu(currentUser.userId, mealMenuId);
+    const mealMenu = await this.mealMenusService.likeMealMenu(currentUser.userId, mealMenuId);
+    return this.toReactionResponse(ActionType.LIKE, mealMenu);
   }
 
   @Post(':mealMenuId/dislike')
@@ -61,6 +68,58 @@ export class MealMenusController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
   ): Promise<MealMenuReactionResponseDto> {
-    return this.mealMenusService.dislikeMealMenu(currentUser.userId, mealMenuId);
+    const mealMenu = await this.mealMenusService.dislikeMealMenu(currentUser.userId, mealMenuId);
+    return this.toReactionResponse(ActionType.DISLIKE, mealMenu);
+  }
+
+  private toListResponse(mealMenus: MealMenu[]): MealMenuListResponseDto {
+    return {
+      items: mealMenus.map((mealMenu) => this.toListItem(mealMenu)),
+    };
+  }
+
+  private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {
+    return {
+      id: mealMenu.id,
+      mealDate: this.formatMealDate(mealMenu.mealDate),
+      mealType: mealMenu.mealType,
+      menuName: mealMenu.menuName,
+      price: mealMenu.price ?? null,
+      calorie: mealMenu.calorie ?? null,
+      likeCount: mealMenu.likeCount,
+      dislikeCount: mealMenu.dislikeCount,
+    };
+  }
+
+  private toDetailResponse(mealMenu: MealMenu): MealMenuDetailResponseDto {
+    return {
+      id: mealMenu.id,
+      mealDate: this.formatMealDate(mealMenu.mealDate),
+      mealType: mealMenu.mealType,
+      menuName: mealMenu.menuName,
+      price: mealMenu.price ?? null,
+      calorie: mealMenu.calorie ?? null,
+      likeCount: mealMenu.likeCount,
+      dislikeCount: mealMenu.dislikeCount,
+    };
+  }
+
+  private toReactionResponse(
+    actionType: ActionType,
+    mealMenu: MealMenu,
+  ): MealMenuReactionResponseDto {
+    return {
+      actionType,
+      likeCount: mealMenu.likeCount,
+      dislikeCount: mealMenu.dislikeCount,
+    };
+  }
+
+  private formatMealDate(mealDate: Date | string): string {
+    if (mealDate instanceof Date) {
+      return mealDate.toISOString().slice(0, 10);
+    }
+
+    return String(mealDate);
   }
 }

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -1,11 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
 import { GetMealMenuRankingQueryDto } from './dto/get-meal-menu-ranking-query.dto';
-import { MealMenuDetailResponseDto } from './dto/meal-menu-detail-response.dto';
-import { MealMenuListItemResponseDto } from './dto/meal-menu-list-item-response.dto';
-import { MealMenuListResponseDto } from './dto/meal-menu-list-response.dto';
-import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.dto';
-import { ActionType } from './entities/meal-menu-reaction.entity';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenuRepository } from './meal-menus.repository';
 
@@ -13,52 +8,39 @@ import { MealMenuRepository } from './meal-menus.repository';
 export class MealMenusService {
   constructor(private readonly mealMenuRepository: MealMenuRepository) {}
 
-  async findMealMenus(query: GetMealMenuListQueryDto): Promise<MealMenuListResponseDto> {
-    const mealMenus = await this.mealMenuRepository.findMany({
+  async findMealMenus(query: GetMealMenuListQueryDto): Promise<MealMenu[]> {
+    return this.mealMenuRepository.findMany({
       mealDate: query.mealDate,
       mealType: query.mealType,
     });
-
-    return this.toListResponse(mealMenus);
   }
 
-  async findMealMenuRankings(query: GetMealMenuRankingQueryDto): Promise<MealMenuListResponseDto> {
-    const mealMenus = await this.mealMenuRepository.findRankings({
+  async findMealMenuRankings(query: GetMealMenuRankingQueryDto): Promise<MealMenu[]> {
+    return this.mealMenuRepository.findRankings({
       mealDate: query.mealDate,
       mealType: query.mealType,
       actionType: query.actionType,
     });
-
-    return this.toListResponse(mealMenus);
   }
 
-  async findMealMenuById(mealMenuId: number): Promise<MealMenuDetailResponseDto> {
-    const mealMenu = await this.findMealMenuOrFail(mealMenuId);
-    return this.toDetailResponse(mealMenu);
+  async findMealMenuById(mealMenuId: number): Promise<MealMenu> {
+    return this.findMealMenuOrFail(mealMenuId);
   }
 
-  async likeMealMenu(
-    userId: number,
-    mealMenuId: number,
-  ): Promise<MealMenuReactionResponseDto> {
+  async likeMealMenu(userId: number, mealMenuId: number): Promise<MealMenu> {
     await this.findMealMenuOrFail(mealMenuId);
 
-    const updatedMealMenu = await this.mealMenuRepository.applyLike(userId, mealMenuId);
-    return this.toReactionResponse(ActionType.LIKE, updatedMealMenu);
+    return this.mealMenuRepository.applyLike(userId, mealMenuId);
   }
 
-  async dislikeMealMenu(
-    userId: number,
-    mealMenuId: number,
-  ): Promise<MealMenuReactionResponseDto> {
+  async dislikeMealMenu(userId: number, mealMenuId: number): Promise<MealMenu> {
     await this.findMealMenuOrFail(mealMenuId);
 
-    const updatedMealMenu = await this.mealMenuRepository.applyDislike(userId, mealMenuId);
-    return this.toReactionResponse(ActionType.DISLIKE, updatedMealMenu);
+    return this.mealMenuRepository.applyDislike(userId, mealMenuId);
   }
 
-  // Keep controllers thin: service owns domain-level not-found handling and
-  // chooses the response DTO shape for each MealMenu use case.
+  // Service owns MealMenu domain lookup and state transitions while controllers
+  // choose how those domain results are exposed in HTTP responses.
   private async findMealMenuOrFail(mealMenuId: number): Promise<MealMenu> {
     const mealMenu = await this.mealMenuRepository.findById(mealMenuId);
 
@@ -67,60 +49,5 @@ export class MealMenusService {
     }
 
     return mealMenu;
-  }
-
-  private toListResponse(mealMenus: MealMenu[]): MealMenuListResponseDto {
-    return {
-      items: mealMenus.map((mealMenu) => this.toListItem(mealMenu)),
-    };
-  }
-
-  private toReactionResponse(
-    actionType: ActionType,
-    mealMenu: MealMenu,
-  ): MealMenuReactionResponseDto {
-    return {
-      actionType,
-      likeCount: mealMenu.likeCount,
-      dislikeCount: mealMenu.dislikeCount,
-    };
-  }
-
-  // Keep list responses independent so later list-only fields can change without
-  // coupling them to detail responses.
-  private toListItem(mealMenu: MealMenu): MealMenuListItemResponseDto {
-    return {
-      id: mealMenu.id,
-      mealDate: this.formatMealDate(mealMenu.mealDate),
-      mealType: mealMenu.mealType,
-      menuName: mealMenu.menuName,
-      price: mealMenu.price ?? null,
-      calorie: mealMenu.calorie ?? null,
-      likeCount: mealMenu.likeCount,
-      dislikeCount: mealMenu.dislikeCount,
-    };
-  }
-
-  // Keep detail responses mapped separately even while the current fields match
-  // list items, so the detail contract can evolve on its own.
-  private toDetailResponse(mealMenu: MealMenu): MealMenuDetailResponseDto {
-    return {
-      id: mealMenu.id,
-      mealDate: this.formatMealDate(mealMenu.mealDate),
-      mealType: mealMenu.mealType,
-      menuName: mealMenu.menuName,
-      price: mealMenu.price ?? null,
-      calorie: mealMenu.calorie ?? null,
-      likeCount: mealMenu.likeCount,
-      dislikeCount: mealMenu.dislikeCount,
-    };
-  }
-
-  private formatMealDate(mealDate: Date | string): string {
-    if (mealDate instanceof Date) {
-      return mealDate.toISOString().slice(0, 10);
-    }
-
-    return String(mealDate);
   }
 }


### PR DESCRIPTION
## 연관된 이슈

- #86

## 📝 작업 내용

- [x] MealMenu Service의 반환 타입을 프레젠테이션 DTO 의존 없이 정리
- [x] MealMenu Controller에서 목록/상세/반응 응답 DTO 매핑 기준 정리
- [x] Service와 Controller의 책임 경계를 다시 정의하고 현재 구조와 충돌하는 지점 정리
- [x] 기존 MealMenu API 응답 shape와 상태 코드 유지 검증
