### PR TITLE
방 멤버 조회 및 사용자가 참여중인 방 조회 API 구현

### DIFF
--- a/src/rooms/dto/room-member.response.dto.ts
+++ b/src/rooms/dto/room-member.response.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResponseRoomMemberDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  nickname: string;
+
+  @ApiProperty()
+  age: number;
+
+  @ApiProperty({ enum: ['MALE', 'FEMALE'] })
+  gender: 'MALE' | 'FEMALE';
+
+  @ApiProperty()
+  schoolInfo: string;
+
+  @ApiProperty()
+  mbti: string | null;
+}
+
+export class ResponseRoomMemberListDto {
+  @ApiProperty()
+  items: ResponseRoomMemberDto[];
+}

--- a/src/rooms/dto/room-response.dto.ts
+++ b/src/rooms/dto/room-response.dto.ts
@@ -1,19 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { RoomStatus, RoomType } from '../entities/room.entity';
-
-export class ResponseRoomMemberDto {
-  @ApiProperty()
-  id: number;
-
-  @ApiProperty()
-  nickname: string;
-
-  @ApiProperty({ enum: ['MALE', 'FEMALE'] })
-  gender: 'MALE' | 'FEMALE';
-
-  @ApiProperty()
-  schoolInfo: string;
-}
+import { ResponseRoomMemberDto } from './room-member.response.dto';
 
 export class ResponseRoomItemDto {
   @ApiProperty()

--- a/src/rooms/mappers/room-member.mapper.ts
+++ b/src/rooms/mappers/room-member.mapper.ts
@@ -1,0 +1,22 @@
+import { calculateAge } from 'src/commons/utils/age.util';
+import { RoomMember } from '../entities/room-member.entity';
+import { ResponseRoomMemberDto, ResponseRoomMemberListDto } from '../dto/room-member.response.dto';
+
+export class RoomMemberMapper {
+  static toItemDto(roomMember: RoomMember): ResponseRoomMemberDto {
+    return {
+      id: roomMember.user.id,
+      nickname: roomMember.user.nickname,
+      age: calculateAge(roomMember.user.birthDate),
+      gender: roomMember.user.gender,
+      schoolInfo: roomMember.user.schoolInfo,
+      mbti: roomMember.user.mbti,
+    };
+  }
+
+  static toListDto(roomMembers: RoomMember[]): ResponseRoomMemberListDto {
+    return {
+      items: roomMembers.map((roomMember) => this.toItemDto(roomMember)),
+    };
+  }
+}

--- a/src/rooms/mappers/room.mapper.ts
+++ b/src/rooms/mappers/room.mapper.ts
@@ -4,6 +4,7 @@ import {
   ResponseRoomItemDto,
 } from '../dto/room-response.dto';
 import { Room } from '../entities/room.entity';
+import { RoomMemberMapper } from './room-member.mapper';
 
 export class RoomMapper {
   static toItemDto(room: Room): ResponseRoomItemDto {
@@ -39,12 +40,7 @@ export class RoomMapper {
     return {
       ...this.toItemDto(room),
       createdAt: room.createdAt,
-      roomMembers: room.roomMembers.map((member) => ({
-        id: member.user.id,
-        nickname: member.user.nickname,
-        gender: member.user.gender,
-        schoolInfo: member.user.schoolInfo,
-      })),
+      roomMembers: room.roomMembers.map((member) => RoomMemberMapper.toItemDto(member)),
     };
   }
 }

--- a/src/rooms/mappers/room.mapper.ts
+++ b/src/rooms/mappers/room.mapper.ts
@@ -20,7 +20,7 @@ export class RoomMapper {
       maxAge: room.maxAge,
       place: room.place,
       lunchAt: room.lunchAt,
-      hostUserId: room.hostUser.id,
+      hostUserId: room.hostUserId,
     };
   }
 

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -38,29 +38,6 @@ export class RoomRepository {
     });
   }
 
-  async createRoomMember(
-    manager: EntityManager,
-    userId: number,
-    roomId: number,
-  ): Promise<RoomMember> {
-    return await manager.save(RoomMember, {
-      room: { id: roomId },
-      user: { id: userId },
-    });
-  }
-
-  async findParticipatingRoom(userId: number): Promise<RoomMember | null> {
-    return await this.roomMemberRepository.findOne({
-      where: {
-        user: { id: userId },
-        room: { status: RoomStatus.OPEN },
-      },
-      relations: {
-        room: true,
-      },
-    });
-  }
-
   async findRoomById(roomId: number, manager?: EntityManager): Promise<Room | null> {
     const queryOptions = {
       where: { id: roomId },

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -70,6 +70,11 @@ export class RoomRepository {
           user: true,
         },
       },
+      order: {
+        roomMembers: {
+          createdAt: 'ASC' as const,
+        },
+      },
     };
 
     if (manager) return await manager.findOne(Room, queryOptions);

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -48,7 +48,16 @@ void hostUser;
 const mockRoomDetailDto = {
   ...roomEntityBase,
   hostUserId: mockUserSummary.id,
-  roomMembers: [mockUserSummary],
+  roomMembers: [
+    {
+      id: mockUserSummary.id,
+      nickname: mockUserSummary.nickname,
+      age: 26,
+      gender: mockUserSummary.gender,
+      schoolInfo: mockUserSummary.schoolInfo,
+      mbti: null,
+    },
+  ],
 };
 
 const mockRoomListDto = {

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -52,7 +52,7 @@ const mockRoomDetailDto = {
     {
       id: mockUserSummary.id,
       nickname: mockUserSummary.nickname,
-      age: 26,
+      age: 27,
       gender: mockUserSummary.gender,
       schoolInfo: mockUserSummary.schoolInfo,
       mbti: null,
@@ -98,10 +98,8 @@ const mockManager = {
 
 const mockRoomRepository = {
   createRoom: jest.fn(),
-  createRoomMember: jest.fn(),
   findRoomById: jest.fn(),
   findRooms: jest.fn(),
-  findParticipatingRoom: jest.fn(),
   updateRoom: jest.fn(),
   deleteRoom: jest.fn(),
   increaseCurrentMembersCount: jest.fn(),
@@ -110,6 +108,9 @@ const mockRoomRepository = {
 };
 
 const mockRoomMemberService = {
+  createRoomMember: jest.fn(),
+  findParticipatingRoomByUserId: jest.fn(),
+  findRoomMembersByRoomId: jest.fn(),
   findRoomMemberCount: jest.fn(),
   joinRoom: jest.fn(),
   leaveRoom: jest.fn(),
@@ -276,9 +277,9 @@ describe('RoomService', () => {
 
   describe('createRoom', () => {
     it('방을 생성하고 생성된 방의 정보를 반환', async () => {
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomRepository.createRoom.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.createRoomMember.mockResolvedValueOnce({
+      mockRoomMemberService.createRoomMember.mockResolvedValueOnce({
         room: { id: mockRoomEntity.id },
         user: { id: mockUserSummary.id },
       });
@@ -288,7 +289,9 @@ describe('RoomService', () => {
       const result = await roomService.createRoom(mockUserSummary.id, createRoomDto);
 
       expect(result).toEqual(mockRoomDetailDto);
-      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
+        mockUserSummary.id,
+      );
       expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
       expect(roomMapperSpy).toHaveBeenCalledWith(mockRoomEntity);
       expect(mockRoomRepository.createRoom).toHaveBeenCalledWith(
@@ -296,7 +299,7 @@ describe('RoomService', () => {
         mockUserSummary.id,
         createRoomDto,
       );
-      expect(mockRoomRepository.createRoomMember).toHaveBeenCalledWith(
+      expect(mockRoomMemberService.createRoomMember).toHaveBeenCalledWith(
         mockManager,
         mockUserSummary.id,
         mockRoomEntity.id,
@@ -305,21 +308,21 @@ describe('RoomService', () => {
     });
 
     it('이미 참여중인 방이 있는 사용자가 방을 생성하면 BadRequestException을 반환', async () => {
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce({ id: 99 });
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce({ id: 99 });
 
       await expect(roomService.createRoom(mockUserSummary.id, createRoomDto)).rejects.toThrow(
         BadRequestException,
       );
 
       expect(mockRoomRepository.createRoom).not.toHaveBeenCalled();
-      expect(mockRoomRepository.createRoomMember).not.toHaveBeenCalled();
+      expect(mockRoomMemberService.createRoomMember).not.toHaveBeenCalled();
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('방 생성 중 createRoom이 실패하면 예외를 던지고 이후 로직을 실행하지 않음', async () => {
       const createRoomError = new Error('create room failed');
 
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomRepository.createRoom.mockRejectedValueOnce(createRoomError);
 
       await expect(roomService.createRoom(mockUserSummary.id, createRoomDto)).rejects.toThrow(
@@ -331,7 +334,7 @@ describe('RoomService', () => {
         mockUserSummary.id,
         createRoomDto,
       );
-      expect(mockRoomRepository.createRoomMember).not.toHaveBeenCalled();
+      expect(mockRoomMemberService.createRoomMember).not.toHaveBeenCalled();
       expect(mockRoomRepository.findRoomById).not.toHaveBeenCalled();
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
@@ -339,9 +342,9 @@ describe('RoomService', () => {
     it('방 생성 중 createRoomMember가 실패하면 예외를 던지고 최종 조회를 실행하지 않음', async () => {
       const createRoomMemberError = new Error('create room member failed');
 
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomRepository.createRoom.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.createRoomMember.mockRejectedValueOnce(createRoomMemberError);
+      mockRoomMemberService.createRoomMember.mockRejectedValueOnce(createRoomMemberError);
 
       await expect(roomService.createRoom(mockUserSummary.id, createRoomDto)).rejects.toThrow(
         createRoomMemberError,
@@ -352,7 +355,7 @@ describe('RoomService', () => {
         mockUserSummary.id,
         createRoomDto,
       );
-      expect(mockRoomRepository.createRoomMember).toHaveBeenCalledWith(
+      expect(mockRoomMemberService.createRoomMember).toHaveBeenCalledWith(
         mockManager,
         mockUserSummary.id,
         mockRoomEntity.id,
@@ -362,9 +365,9 @@ describe('RoomService', () => {
     });
 
     it('방 생성 후 findRoomById가 null을 반환하면 NotFoundException을 던짐', async () => {
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomRepository.createRoom.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.createRoomMember.mockResolvedValueOnce({
+      mockRoomMemberService.createRoomMember.mockResolvedValueOnce({
         room: { id: mockRoomEntity.id },
         user: { id: mockUserSummary.id },
       });
@@ -379,7 +382,7 @@ describe('RoomService', () => {
         mockUserSummary.id,
         createRoomDto,
       );
-      expect(mockRoomRepository.createRoomMember).toHaveBeenCalledWith(
+      expect(mockRoomMemberService.createRoomMember).toHaveBeenCalledWith(
         mockManager,
         mockUserSummary.id,
         mockRoomEntity.id,
@@ -389,7 +392,7 @@ describe('RoomService', () => {
     });
 
     it('최소 나이가 최대 나이보다 크면 BadRequestException을 반환', async () => {
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
 
       await expect(
         roomService.createRoom(mockUserSummary.id, {
@@ -399,12 +402,14 @@ describe('RoomService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
 
-      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
+        mockUserSummary.id,
+      );
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('과거 lunchAt으로 방을 생성하면 BadRequestException을 반환', async () => {
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
 
       await expect(
         roomService.createRoom(mockUserSummary.id, {
@@ -413,7 +418,9 @@ describe('RoomService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
 
-      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
+        mockUserSummary.id,
+      );
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
   });
@@ -590,7 +597,7 @@ describe('RoomService', () => {
 
       mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
       mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(1);
       mockRoomRepository.increaseCurrentMembersCount.mockResolvedValueOnce(undefined);
       mockRoomMemberService.joinRoom.mockResolvedValueOnce(newMember);
@@ -600,7 +607,9 @@ describe('RoomService', () => {
       expect(result).toEqual(newMember);
       expect(mockUserService.findMe).toHaveBeenCalledWith(mockUserSummary.id);
       expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
-      expect(mockRoomRepository.findParticipatingRoom).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
+        mockUserSummary.id,
+      );
       expect(mockRoomMemberService.findRoomMemberCount).toHaveBeenCalledWith(
         mockManager,
         mockRoomEntity.id,
@@ -624,13 +633,13 @@ describe('RoomService', () => {
         NotFoundException,
       );
 
-      expect(mockRoomRepository.findParticipatingRoom).not.toHaveBeenCalled();
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).not.toHaveBeenCalled();
     });
 
     it('이미 참여 중이면 BadRequestException을 반환', async () => {
       mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
       mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce({ id: 123 });
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce({ id: 123 });
 
       await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
         BadRequestException,
@@ -642,7 +651,7 @@ describe('RoomService', () => {
     it('정원이 가득 찼으면 BadRequestException을 반환', async () => {
       mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
       mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
       mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(
         mockRoomEntity.maxMembersCount,
       );
@@ -660,7 +669,7 @@ describe('RoomService', () => {
         gender: 'FEMALE',
       });
       mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
-      mockRoomRepository.findParticipatingRoom.mockResolvedValueOnce(null);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
 
       await expect(roomService.joinRoom(mockRoomEntity.id, mockUserSummary.id)).rejects.toThrow(
         BadRequestException,
@@ -756,7 +765,11 @@ describe('RoomService', () => {
         mockManager,
         mockRoomEntity.id,
       );
-      expect(mockRoomMemberService.leaveRoom).toHaveBeenCalledWith(mockManager, mockRoomEntity.id, 2);
+      expect(mockRoomMemberService.leaveRoom).toHaveBeenCalledWith(
+        mockManager,
+        mockRoomEntity.id,
+        2,
+      );
     });
 
     it('방장이 아닌 사용자가 강제 퇴장시키면 ForbiddenException을 반환', async () => {
@@ -783,9 +796,9 @@ describe('RoomService', () => {
       mockRoomRepository.findRoomById.mockResolvedValueOnce(mockRoomEntity);
       mockRoomMemberService.isRoomMember.mockResolvedValueOnce(false);
 
-      await expect(roomService.kickRoomMember(mockRoomEntity.id, 2, mockUserSummary.id)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        roomService.kickRoomMember(mockRoomEntity.id, 2, mockUserSummary.id),
+      ).rejects.toThrow(BadRequestException);
 
       expect(mockRoomRepository.decreaseCurrentMembersCount).not.toHaveBeenCalled();
     });

--- a/src/rooms/roomMember.repository.ts
+++ b/src/rooms/roomMember.repository.ts
@@ -10,9 +10,15 @@ export class RoomMemberRepository {
     private readonly roomMemberRepository: Repository<RoomMember>,
   ) {}
 
-  async findRoomMembersById(roomid: number): Promise<RoomMember[]> {
+  async findRoomMembersByRoomId(roomId: number): Promise<RoomMember[]> {
     return await this.roomMemberRepository.find({
-      where: { room: { id: roomid } },
+      where: { room: { id: roomId } },
+      relations: {
+        user: true,
+      },
+      order: {
+        createdAt: 'ASC',
+      },
     });
   }
 

--- a/src/rooms/roomMember.repository.ts
+++ b/src/rooms/roomMember.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { RoomMember } from './entities/room-member.entity';
 import { EntityManager, Not, Repository } from 'typeorm';
+import { RoomStatus } from './entities/room.entity';
 
 @Injectable()
 export class RoomMemberRepository {
@@ -9,6 +10,41 @@ export class RoomMemberRepository {
     @InjectRepository(RoomMember)
     private readonly roomMemberRepository: Repository<RoomMember>,
   ) {}
+
+  async createRoomMember(
+    manager: EntityManager,
+    userId: number,
+    roomId: number,
+  ): Promise<RoomMember> {
+    return await manager.save(RoomMember, {
+      room: { id: roomId },
+      user: { id: userId },
+    });
+  }
+
+  async findParticipatingRoomByUserId(userId: number): Promise<RoomMember | null> {
+    return await this.roomMemberRepository.findOne({
+      where: {
+        user: { id: userId },
+        room: { status: RoomStatus.OPEN },
+      },
+      relations: {
+        room: {
+          hostUser: true,
+          roomMembers: {
+            user: true,
+          },
+        },
+      },
+      order: {
+        room: {
+          roomMembers: {
+            createdAt: 'ASC',
+          },
+        },
+      },
+    });
+  }
 
   async findRoomMembersByRoomId(roomId: number): Promise<RoomMember[]> {
     return await this.roomMemberRepository.find({

--- a/src/rooms/roomMember.service.ts
+++ b/src/rooms/roomMember.service.ts
@@ -3,6 +3,7 @@ import { RoomMemberRepository } from './roomMember.repository';
 import { EntityManager } from 'typeorm';
 import { ResponseRoomMemberListDto } from './dto/room-member.response.dto';
 import { RoomMemberMapper } from './mappers/room-member.mapper';
+import { RoomMember } from './entities/room-member.entity';
 
 @Injectable()
 export class RoomMemberService {
@@ -15,6 +16,18 @@ export class RoomMemberService {
 
   async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {
     return await this.roomMemberRepository.findRoomMemberCount(manager, roomId);
+  }
+
+  async findParticipatingRoomByUserId(userId: number) {
+    return await this.roomMemberRepository.findParticipatingRoomByUserId(userId);
+  }
+
+  async createRoomMember(
+    manager: EntityManager,
+    userId: number,
+    roomId: number,
+  ): Promise<RoomMember> {
+    return await this.roomMemberRepository.createRoomMember(manager, userId, roomId);
   }
 
   async joinRoom(manager: EntityManager, roomId: number, userId: number) {

--- a/src/rooms/roomMember.service.ts
+++ b/src/rooms/roomMember.service.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { RoomMemberRepository } from './roomMember.repository';
 import { EntityManager } from 'typeorm';
-import { RoomMember } from './entities/room-member.entity';
+import { ResponseRoomMemberListDto } from './dto/room-member.response.dto';
+import { RoomMemberMapper } from './mappers/room-member.mapper';
 
 @Injectable()
 export class RoomMemberService {
   constructor(private readonly roomMemberRepository: RoomMemberRepository) {}
 
-  async findRoomMembersById(roomId: number): Promise<RoomMember[]> {
-    return await this.roomMemberRepository.findRoomMembersById(roomId);
+  async findRoomMembersByRoomId(roomId: number): Promise<ResponseRoomMemberListDto> {
+    const roomMembers = await this.roomMemberRepository.findRoomMembersByRoomId(roomId);
+    return RoomMemberMapper.toListDto(roomMembers);
   }
 
   async findRoomMemberCount(manager: EntityManager, roomId: number): Promise<number> {

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -46,6 +46,16 @@ import { ResponseRoomMemberListDto } from './dto/room-member.response.dto';
 export class RoomController {
   constructor(private readonly roomService: RoomService) {}
 
+  @Get('me')
+  @Authenticated()
+  @ApiOperation({ summary: '현재 사용자가 참여 중인 방 조회' })
+  @ApiOkResponse({ type: ResponseRoomDetailDto })
+  @ApiNotFoundResponse({ description: '현재 참여 중인 방이 없는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async findRoomByUserId(@CurrentUser() user: AuthenticatedUser): Promise<ResponseRoomDetailDto> {
+    return await this.roomService.findParticipatingRoomByUserId(user.userId);
+  }
+
   @Authenticated()
   @Post()
   @ApiOperation({ summary: '방 생성' })

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -38,9 +38,10 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
 import { RoomMember } from './entities/room-member.entity';
+import { ResponseRoomMemberListDto } from './dto/room-member.response.dto';
 
 @ApiTags('Room')
-@ApiExtraModels(ResponseRoomListDto, ResponseRoomDetailDto)
+@ApiExtraModels(ResponseRoomListDto, ResponseRoomDetailDto, ResponseRoomMemberListDto)
 @Controller('rooms')
 export class RoomController {
   constructor(private readonly roomService: RoomService) {}
@@ -189,5 +190,16 @@ export class RoomController {
     @CurrentUser() user: AuthenticatedUser,
   ) {
     await this.roomService.kickRoomMember(roomId, userId, user.userId);
+  }
+
+  @Get(':id/members')
+  @ApiOperation({ summary: '방 멤버 조회' })
+  @ApiParam({ name: 'id', description: '멤버를 조회할 방 ID', type: Number })
+  @ApiOkResponse({ type: ResponseRoomMemberListDto })
+  @ApiNotFoundResponse({ description: '존재하지 않는 방의 멤버를 조회하려는 경우' })
+  async findRoomMembersById(
+    @Param('id', ParseIntPipe) roomId: number,
+  ): Promise<ResponseRoomMemberListDto> {
+    return await this.roomService.findRoomMembersByRoomId(roomId);
   }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -43,7 +43,7 @@ export class RoomService {
 
       const roomId = newRoom.id;
 
-      await this.roomRepository.createRoomMember(manager, userId, roomId);
+      await this.roomMemberService.createRoomMember(manager, userId, roomId);
 
       return roomId;
     });
@@ -91,6 +91,14 @@ export class RoomService {
     await this.findExistingRoomOrThrow(roomId);
 
     return await this.roomMemberService.findRoomMembersByRoomId(roomId);
+  }
+
+  async findParticipatingRoomByUserId(userId: number) {
+    const room = await this.roomMemberService.findParticipatingRoomByUserId(userId);
+
+    if (!room) throw new BadRequestException('현재 참여중인 방이 없습니다.');
+
+    return RoomMapper.toDetailDto(room.room);
   }
 
   async updateRoom(
@@ -241,7 +249,7 @@ export class RoomService {
   }
 
   async validateParticipatingRoom(userId: number): Promise<void> {
-    const participatingRoom = await this.roomRepository.findParticipatingRoom(userId);
+    const participatingRoom = await this.roomMemberService.findParticipatingRoomByUserId(userId);
     if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
   }
 

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -87,6 +87,12 @@ export class RoomService {
     };
   }
 
+  async findRoomMembersByRoomId(roomId: number) {
+    await this.findExistingRoomOrThrow(roomId);
+
+    return await this.roomMemberService.findRoomMembersByRoomId(roomId);
+  }
+
   async updateRoom(
     roomId: number,
     updateRoomDto: UpdateRoomDto,

--- a/test/rooms-create.e2e-spec.ts
+++ b/test/rooms-create.e2e-spec.ts
@@ -58,7 +58,12 @@ describe('Rooms Create (e2e)', () => {
     expect(response.body.hostUserId).toBe(signupResponse.body.user.id);
     expect(response.body.currentMembersCount).toBe(1);
     expect(response.body.roomMembers).toHaveLength(1);
+    expect(response.body.roomMembers[0].id).toBe(signupResponse.body.user.id);
     expect(response.body.roomMembers[0].nickname).toBe('길동홍');
+    expect(response.body.roomMembers[0].age).toBe(26);
+    expect(response.body.roomMembers[0].gender).toBe('MALE');
+    expect(response.body.roomMembers[0].schoolInfo).toBe('인덕대학교');
+    expect(response.body.roomMembers[0].mbti).toBeNull();
     expect(response.body.lunchAt).toBe(lunchAt);
 
     const createdRoom = await dataSource.getRepository(Room).findOne({

--- a/test/rooms-create.e2e-spec.ts
+++ b/test/rooms-create.e2e-spec.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { Room } from '../src/rooms/entities/room.entity';
+import { calculateAge } from '../src/commons/utils/age.util';
 import { createAuthUserTestApp } from './test-app';
 import { clearRoomTables, futureLunchAt } from './rooms.e2e-helper';
 
@@ -60,7 +61,7 @@ describe('Rooms Create (e2e)', () => {
     expect(response.body.roomMembers).toHaveLength(1);
     expect(response.body.roomMembers[0].id).toBe(signupResponse.body.user.id);
     expect(response.body.roomMembers[0].nickname).toBe('길동홍');
-    expect(response.body.roomMembers[0].age).toBe(26);
+    expect(response.body.roomMembers[0].age).toBe(calculateAge('2000-01-01'));
     expect(response.body.roomMembers[0].gender).toBe('MALE');
     expect(response.body.roomMembers[0].schoolInfo).toBe('인덕대학교');
     expect(response.body.roomMembers[0].mbti).toBeNull();

--- a/test/rooms-read.e2e-spec.ts
+++ b/test/rooms-read.e2e-spec.ts
@@ -107,6 +107,11 @@ describe('Rooms Read (e2e)', () => {
     expect(response.body.lunchAt).toBe(lunchAt);
     expect(response.body.createdAt).toBe(new Date(room.createdAt).toISOString());
     expect(response.body.roomMembers).toHaveLength(1);
+    expect(response.body.roomMembers[0].id).toBe(hostUser.id);
     expect(response.body.roomMembers[0].nickname).toBe('상세호스트');
+    expect(response.body.roomMembers[0].age).toBe(26);
+    expect(response.body.roomMembers[0].gender).toBe('MALE');
+    expect(response.body.roomMembers[0].schoolInfo).toBe('인덕대학교');
+    expect(response.body.roomMembers[0].mbti).toBeNull();
   });
 });

--- a/test/rooms-read.e2e-spec.ts
+++ b/test/rooms-read.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { calculateAge } from '../src/commons/utils/age.util';
 import { RoomStatus, RoomType } from '../src/rooms/entities/room.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -109,7 +110,7 @@ describe('Rooms Read (e2e)', () => {
     expect(response.body.roomMembers).toHaveLength(1);
     expect(response.body.roomMembers[0].id).toBe(hostUser.id);
     expect(response.body.roomMembers[0].nickname).toBe('상세호스트');
-    expect(response.body.roomMembers[0].age).toBe(26);
+    expect(response.body.roomMembers[0].age).toBe(calculateAge('2000-01-01'));
     expect(response.body.roomMembers[0].gender).toBe('MALE');
     expect(response.body.roomMembers[0].schoolInfo).toBe('인덕대학교');
     expect(response.body.roomMembers[0].mbti).toBeNull();


### PR DESCRIPTION
## 연관된 이슈

- #85 

## 📝 작업 내용

### 방 멤버 조회
- [x] `GET /rooms/:id/members` 방 멤버 조회 API 구현
- [x] `RoomController`에 방 멤버 조회 엔드포인트 추가
- [x] 방 멤버 조회 Swagger 문서화 추가
- [x] 방 존재 여부 검증 추가
- [x] `RoomService` 방 멤버 조회 로직 구현
- [x] `RoomMemberService` 방 멤버 조회 메서드 구현
- [x] `RoomMemberRepository` 방 멤버 목록 조회 로직 구현
- [x] 방 멤버 응답 DTO/매퍼 수정 후 적용
- [x] 방 멤버 정렬 적용
- [x] 방 멤버 응답 형태 변경을 기존 room 테스트에 반영

### 사용자가 참여중인 방 조회
- [x] `GET /rooms/me` 현재 사용자가 참여 중인 방 조회 API 구현
- [x] `RoomController`에 `/rooms/me` 엔드포인트 추가
- [x] `/rooms/me` Swagger 문서화 추가
- [x] `RoomService` 참여 중인 방 조회 로직 구현
- [x] `RoomMemberService` 참여 중인 방 조회 메서드 구현
- [x] `RoomMemberRepository` 사용자가 참여 중인 OPEN 상태의 방 조회 로직 구현
- [x] 참여 중인 방 조회 시 `room`, `hostUser`, `roomMembers.user` relation 함께 조회
- [x] 참여 중인 방이 없을 때 예외 처리 추가