### PR TITLE
Friend Controller 응답 매핑 경계 재정리

### DIFF
--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -20,10 +20,14 @@ import {
 import { Authenticated } from '../auth/decorators/authenticated.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { PublicUserResponseDto } from '../users/dto/public-user-response.dto';
+import { User } from '../users/entities/user.entity';
 import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
+import { FriendListItemResponseDto } from './dto/friend-list-item-response.dto';
 import { FriendListResponseDto } from './dto/friend-list-response.dto';
 import { FriendRequestResponseDto } from './dto/friend-request-response.dto';
 import { GetFriendListQueryDto } from './dto/get-friend-list-query.dto';
+import { Friend } from './entities/friend.entity';
 import { FriendService } from './friends.service';
 
 @ApiTags('Friend')
@@ -39,7 +43,8 @@ export class FriendController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Query() query: GetFriendListQueryDto,
   ): Promise<FriendListResponseDto> {
-    return this.friendService.findFriends(currentUser.userId, query.status);
+    const friends = await this.friendService.findFriends(currentUser.userId, query.status);
+    return this.toFriendListResponse(friends, currentUser.userId);
   }
 
   @Post('requests')
@@ -50,7 +55,11 @@ export class FriendController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Body() createFriendRequestDto: CreateFriendRequestDto,
   ): Promise<FriendRequestResponseDto> {
-    return this.friendService.createRequest(currentUser.userId, createFriendRequestDto.receiverId);
+    const friend = await this.friendService.createRequest(
+      currentUser.userId,
+      createFriendRequestDto.receiverId,
+    );
+    return this.toFriendRequestResponse(friend);
   }
 
   @Patch('requests/:friendshipId/accept')
@@ -61,7 +70,8 @@ export class FriendController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Param('friendshipId', ParseIntPipe) friendshipId: number,
   ): Promise<FriendRequestResponseDto> {
-    return this.friendService.acceptRequest(currentUser.userId, friendshipId);
+    const friend = await this.friendService.acceptRequest(currentUser.userId, friendshipId);
+    return this.toFriendRequestResponse(friend);
   }
 
   @Patch('requests/:friendshipId/reject')
@@ -72,7 +82,8 @@ export class FriendController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Param('friendshipId', ParseIntPipe) friendshipId: number,
   ): Promise<FriendRequestResponseDto> {
-    return this.friendService.rejectRequest(currentUser.userId, friendshipId);
+    const friend = await this.friendService.rejectRequest(currentUser.userId, friendshipId);
+    return this.toFriendRequestResponse(friend);
   }
 
   @Delete('requests/:friendshipId')
@@ -97,5 +108,47 @@ export class FriendController {
     @Param('friendshipId', ParseIntPipe) friendshipId: number,
   ): Promise<void> {
     await this.friendService.deleteFriend(currentUser.userId, friendshipId);
+  }
+
+  private toFriendRequestResponse(friend: Friend): FriendRequestResponseDto {
+    return {
+      id: friend.id,
+      requesterId: friend.requester.id,
+      receiverId: friend.receiver.id,
+      status: friend.status,
+      createdAt: friend.createdAt,
+    };
+  }
+
+  private toFriendListResponse(
+    friends: Friend[],
+    currentUserId: number,
+  ): FriendListResponseDto {
+    return {
+      items: friends.map((friend) => this.toFriendListItem(friend, currentUserId)),
+    };
+  }
+
+  private toFriendListItem(friend: Friend, currentUserId: number): FriendListItemResponseDto {
+    const otherUser = friend.requester.id === currentUserId ? friend.receiver : friend.requester;
+
+    return {
+      friendshipId: friend.id,
+      status: friend.status,
+      user: this.toPublicUserResponse(otherUser),
+    };
+  }
+
+  private toPublicUserResponse(user: User): PublicUserResponseDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      birthDate: user.birthDate,
+      gender: user.gender,
+      schoolInfo: user.schoolInfo,
+      introduce: user.introduce,
+      mbti: user.mbti,
+      createdAt: user.createdAt,
+    };
   }
 }

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -6,10 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { UserService } from '../users/users.service';
-import { FriendListItemResponseDto } from './dto/friend-list-item-response.dto';
-import { FriendListResponseDto } from './dto/friend-list-response.dto';
 import { Friend, FriendStatus } from './entities/friend.entity';
-import { FriendRequestResponseDto } from './dto/friend-request-response.dto';
 import { FriendRepository } from './friends.repository';
 
 @Injectable()
@@ -19,48 +16,36 @@ export class FriendService {
     private readonly userService: UserService,
   ) {}
 
-  async createRequest(requesterId: number, receiverId: number): Promise<FriendRequestResponseDto> {
+  async createRequest(requesterId: number, receiverId: number): Promise<Friend> {
     await this.validateReceiver(requesterId, receiverId);
     await this.ensureRequestableRelation(requesterId, receiverId);
 
-    const friendRequest = await this.friendRepository.createOrRestoreRequest(
+    return this.friendRepository.createOrRestoreRequest(
       requesterId,
       receiverId,
     );
-
-    return this.toResponse(friendRequest);
   }
 
-  async acceptRequest(
-    currentUserId: number,
-    friendshipId: number,
-  ): Promise<FriendRequestResponseDto> {
+  async acceptRequest(currentUserId: number, friendshipId: number): Promise<Friend> {
     const friendRequest = await this.findRequestOrFail(friendshipId);
     this.ensureReceiverOwnsRequest(friendRequest, currentUserId);
     this.ensurePendingRequest(friendRequest);
 
-    const acceptedRequest = await this.friendRepository.updateStatus(
+    return this.friendRepository.updateStatus(
       friendRequest,
       FriendStatus.ACCEPTED,
     );
-
-    return this.toResponse(acceptedRequest);
   }
 
-  async rejectRequest(
-    currentUserId: number,
-    friendshipId: number,
-  ): Promise<FriendRequestResponseDto> {
+  async rejectRequest(currentUserId: number, friendshipId: number): Promise<Friend> {
     const friendRequest = await this.findRequestOrFail(friendshipId);
     this.ensureReceiverOwnsRequest(friendRequest, currentUserId);
     this.ensurePendingRequest(friendRequest);
 
-    const rejectedRequest = await this.friendRepository.updateStatus(
+    return this.friendRepository.updateStatus(
       friendRequest,
       FriendStatus.REJECTED,
     );
-
-    return this.toResponse(rejectedRequest);
   }
 
   async cancelRequest(currentUserId: number, friendshipId: number): Promise<void> {
@@ -79,14 +64,9 @@ export class FriendService {
     await this.friendRepository.softDelete(friendRelation.id);
   }
 
-  async findFriends(currentUserId: number, status?: 'accepted'): Promise<FriendListResponseDto> {
+  async findFriends(currentUserId: number, status?: 'accepted'): Promise<Friend[]> {
     this.validateFriendListStatus(status);
-
-    const relations = await this.friendRepository.findAcceptedRelationsForUser(currentUserId);
-
-    return {
-      items: relations.map((relation) => this.toFriendListItem(relation, currentUserId)),
-    };
+    return this.friendRepository.findAcceptedRelationsForUser(currentUserId);
   }
 
   private async validateReceiver(requesterId: number, receiverId: number): Promise<void> {
@@ -168,25 +148,5 @@ export class FriendService {
     if (status && status !== 'accepted') {
       throw new BadRequestException('Only status=accepted is supported.');
     }
-  }
-
-  private toResponse(friend: Friend): FriendRequestResponseDto {
-    return {
-      id: friend.id,
-      requesterId: friend.requester.id,
-      receiverId: friend.receiver.id,
-      status: friend.status,
-      createdAt: friend.createdAt,
-    };
-  }
-
-  private toFriendListItem(friend: Friend, currentUserId: number): FriendListItemResponseDto {
-    const otherUser = friend.requester.id === currentUserId ? friend.receiver : friend.requester;
-
-    return {
-      friendshipId: friend.id,
-      status: friend.status,
-      user: this.userService.toPublicResponse(otherUser),
-    };
   }
 }


### PR DESCRIPTION
## 연관된 이슈

- #87

## 📝 작업 내용

- [x] Friend Service의 반환 타입을 프레젠테이션 DTO 의존 없이 정리
- [x] Friend Controller에서 요청 처리 결과와 친구 목록 응답 DTO 매핑 기준 정리
- [x] Service와 Controller의 책임 경계를 다시 정의하고 현재 구조와 충돌하는 지점 정리
- [x] 기존 Friend API 응답 shape와 상태 코드 유지 검증
