### PR TITLE
User Controller 응답 매핑 경계 재정리

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,12 +8,14 @@ import {
 } from '@nestjs/swagger';
 import { Authenticated } from './decorators/authenticated.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
-import { AuthService } from './auth.service';
+import { AuthResult, AuthService, AuthTokensResult } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { SignupDto } from './dto/signup.dto';
 import { AuthResponseDto, AuthTokensResponseDto } from './dto/auth-response.dto';
 import type { AuthenticatedUser } from './interfaces/jwt-payload.interface';
+import { CurrentUserResponseDto } from '../users/dto/current-user-response.dto';
+import { User } from '../users/entities/user.entity';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -23,24 +25,27 @@ export class AuthController {
   @Post('signup')
   @ApiOperation({ summary: '회원가입' })
   @ApiCreatedResponse({ type: AuthResponseDto })
-  signup(@Body() signupDto: SignupDto): Promise<AuthResponseDto> {
-    return this.authService.signup(signupDto);
+  async signup(@Body() signupDto: SignupDto): Promise<AuthResponseDto> {
+    const result = await this.authService.signup(signupDto);
+    return this.toAuthResponse(result);
   }
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '로그인' })
   @ApiOkResponse({ type: AuthResponseDto })
-  login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
-    return this.authService.login(loginDto);
+  async login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
+    const result = await this.authService.login(loginDto);
+    return this.toAuthResponse(result);
   }
 
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '토큰 재발급' })
   @ApiOkResponse({ type: AuthTokensResponseDto })
-  refresh(@Body() refreshTokenDto: RefreshTokenDto): Promise<AuthTokensResponseDto> {
-    return this.authService.refresh(refreshTokenDto);
+  async refresh(@Body() refreshTokenDto: RefreshTokenDto): Promise<AuthTokensResponseDto> {
+    const result = await this.authService.refresh(refreshTokenDto);
+    return this.toAuthTokensResponse(result);
   }
 
   @Post('logout')
@@ -50,5 +55,33 @@ export class AuthController {
   @ApiNoContentResponse()
   async logout(@CurrentUser() currentUser: AuthenticatedUser): Promise<void> {
     await this.authService.logout(currentUser.userId);
+  }
+
+  private toAuthResponse(result: AuthResult): AuthResponseDto {
+    return {
+      ...this.toAuthTokensResponse(result),
+      user: this.toCurrentUserResponse(result.user),
+    };
+  }
+
+  private toAuthTokensResponse(result: AuthTokensResult): AuthTokensResponseDto {
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+    };
+  }
+
+  private toCurrentUserResponse(user: User): CurrentUserResponseDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      birthDate: user.birthDate,
+      gender: user.gender,
+      schoolInfo: user.schoolInfo,
+      introduce: user.introduce,
+      mbti: user.mbti,
+      createdAt: user.createdAt,
+      email: user.email,
+    };
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,12 +4,21 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { UserService } from '../users/users.service';
+import { User } from '../users/entities/user.entity';
 import { AUTH_ERROR_MESSAGES, JWT_DEFAULTS } from './auth.constants';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { SignupDto } from './dto/signup.dto';
-import { AuthResponseDto, AuthTokensResponseDto } from './dto/auth-response.dto';
 import { JwtAccessPayload, JwtRefreshPayload } from './interfaces/jwt-payload.interface';
+
+export type AuthTokensResult = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type AuthResult = AuthTokensResult & {
+  user: User;
+};
 
 @Injectable()
 export class AuthService {
@@ -19,7 +28,7 @@ export class AuthService {
     private readonly configService: ConfigService,
   ) {}
 
-  async signup(signupDto: SignupDto): Promise<AuthResponseDto> {
+  async signup(signupDto: SignupDto): Promise<AuthResult> {
     await this.assertSignupAvailable(signupDto);
     const hashedPassword = await bcrypt.hash(signupDto.password, 10);
     const user = await this.userService.createUser({
@@ -42,21 +51,21 @@ export class AuthService {
 
     return {
       ...tokens,
-      user: this.userService.toMeResponse(user),
+      user,
     };
   }
 
-  async login(loginDto: LoginDto): Promise<AuthResponseDto> {
+  async login(loginDto: LoginDto): Promise<AuthResult> {
     const user = await this.validateCredentials(loginDto);
     const tokens = await this.issueTokens(user.id, user.email, user.nickname, user.tokenVersion);
 
     return {
       ...tokens,
-      user: this.userService.toMeResponse(user),
+      user,
     };
   }
 
-  async refresh(refreshTokenDto: RefreshTokenDto): Promise<AuthTokensResponseDto> {
+  async refresh(refreshTokenDto: RefreshTokenDto): Promise<AuthTokensResult> {
     const payload = await this.verifyRefreshToken(refreshTokenDto.refreshToken);
     const user = await this.userService.findByIdForRefresh(payload.sub);
 
@@ -107,7 +116,7 @@ export class AuthService {
     email: string,
     nickname: string,
     tokenVersion: number,
-  ): Promise<AuthTokensResponseDto> {
+  ): Promise<AuthTokensResult> {
     const tokens = await this.issueTokensWithoutPersisting(userId, email, nickname, tokenVersion);
     const refreshTokenHash = await this.createRefreshTokenHash(tokens.refreshToken);
     await this.userService.updateRefreshTokenHash(userId, refreshTokenHash);
@@ -120,7 +129,7 @@ export class AuthService {
     email: string,
     nickname: string,
     tokenVersion: number,
-  ): Promise<AuthTokensResponseDto> {
+  ): Promise<AuthTokensResult> {
     const accessTokenId = randomUUID();
     const refreshTokenId = randomUUID();
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -16,6 +16,7 @@ import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface
 import { CurrentUserResponseDto } from './dto/current-user-response.dto';
 import { PublicUserResponseDto } from './dto/public-user-response.dto';
 import { UpdateMeDto } from './dto/update-me.dto';
+import { User } from './entities/user.entity';
 import { UserService } from './users.service';
 
 @ApiTags('User')
@@ -30,7 +31,8 @@ export class UserController {
   async getMe(
     @CurrentUser() currentUser: AuthenticatedUser,
   ): Promise<CurrentUserResponseDto> {
-    return this.userService.findMe(currentUser.userId);
+    const user = await this.userService.findMe(currentUser.userId);
+    return this.toCurrentUserResponse(user);
   }
 
   @Patch('me')
@@ -41,7 +43,8 @@ export class UserController {
     @CurrentUser() currentUser: AuthenticatedUser,
     @Body() updateMeDto: UpdateMeDto,
   ): Promise<CurrentUserResponseDto> {
-    return this.userService.updateMe(currentUser.userId, updateMeDto);
+    const user = await this.userService.updateMe(currentUser.userId, updateMeDto);
+    return this.toCurrentUserResponse(user);
   }
 
   @Delete('me')
@@ -59,6 +62,27 @@ export class UserController {
   async findUserById(
     @Param('userId', ParseIntPipe) userId: number,
   ): Promise<PublicUserResponseDto> {
-    return this.userService.findPublicUserById(userId);
+    const user = await this.userService.findPublicUserById(userId);
+    return this.toPublicUserResponse(user);
+  }
+
+  private toPublicUserResponse(user: User): PublicUserResponseDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      birthDate: user.birthDate,
+      gender: user.gender,
+      schoolInfo: user.schoolInfo,
+      introduce: user.introduce,
+      mbti: user.mbti,
+      createdAt: user.createdAt,
+    };
+  }
+
+  private toCurrentUserResponse(user: User): CurrentUserResponseDto {
+    return {
+      ...this.toPublicUserResponse(user),
+      email: user.email,
+    };
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,5 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { User } from './entities/user.entity';
-import { CurrentUserResponseDto } from './dto/current-user-response.dto';
-import { PublicUserResponseDto } from './dto/public-user-response.dto';
 import { UpdateMeDto } from './dto/update-me.dto';
 import { UpdateMePatch, UserRepository } from './users.repository';
 
@@ -85,17 +83,15 @@ export class UserService {
     return user;
   }
 
-  async findPublicUserById(userId: number): Promise<PublicUserResponseDto> {
-    const user = await this.findActiveUserOrFail(userId);
-    return this.toPublicResponse(user);
+  async findPublicUserById(userId: number): Promise<User> {
+    return this.findActiveUserOrFail(userId);
   }
 
-  async findMe(userId: number): Promise<CurrentUserResponseDto> {
-    const user = await this.findActiveUserOrFail(userId);
-    return this.toMeResponse(user);
+  async findMe(userId: number): Promise<User> {
+    return this.findActiveUserOrFail(userId);
   }
 
-  async updateMe(userId: number, updateMeDto: UpdateMeDto): Promise<CurrentUserResponseDto> {
+  async updateMe(userId: number, updateMeDto: UpdateMeDto): Promise<User> {
     const user = await this.findActiveUserOrFail(userId);
     const patch = this.toUpdateMePatch(user, updateMeDto);
 
@@ -104,46 +100,18 @@ export class UserService {
     }
 
     if (Object.keys(patch).length === 0) {
-      return this.toMeResponse(user);
+      return user;
     }
 
     await this.userRepository.updateMe(userId, patch);
 
-    const updatedUser = await this.findActiveUserOrFail(userId);
-    return this.toMeResponse(updatedUser);
+    return this.findActiveUserOrFail(userId);
   }
 
   async withdraw(userId: number): Promise<void> {
     await this.findActiveUserOrFail(userId);
     await this.revokeTokens(userId);
     await this.userRepository.softDelete(userId);
-  }
-
-  toPublicResponse(user: User): PublicUserResponseDto {
-    return {
-      id: user.id,
-      nickname: user.nickname,
-      birthDate: user.birthDate,
-      gender: user.gender,
-      schoolInfo: user.schoolInfo,
-      introduce: user.introduce,
-      mbti: user.mbti,
-      createdAt: user.createdAt,
-    };
-  }
-
-  toMeResponse(user: User): CurrentUserResponseDto {
-    return {
-      id: user.id,
-      nickname: user.nickname,
-      birthDate: user.birthDate,
-      gender: user.gender,
-      schoolInfo: user.schoolInfo,
-      introduce: user.introduce,
-      mbti: user.mbti,
-      createdAt: user.createdAt,
-      email: user.email,
-    };
   }
 
   private toUpdateMePatch(user: User, updateMeDto: UpdateMeDto): UpdateMePatch {


### PR DESCRIPTION
## 연관된 이슈

- #88

## 📝 작업 내용

- [x] User Service의 반환 타입을 프레젠테이션 DTO 의존 없이 정리
- [x] User Controller에서 공개 유저/내 정보 응답 DTO 매핑 기준 정리
- [x] Service와 Controller의 책임 경계를 다시 정의하고 현재 구조와 충돌하는 지점 정리
- [x] 기존 User API 응답 shape와 상태 코드 유지 검증
