### PR TITLE
방 빠른참여 API 구현

### DIFF
--- a/src/rooms/room.repository.spec.ts
+++ b/src/rooms/room.repository.spec.ts
@@ -1,7 +1,6 @@
 import { Between, LessThan, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { RoomRepository } from './room.repository';
 import { Room, RoomStatus, RoomType } from './entities/room.entity';
-import { RoomMember } from './entities/room-member.entity';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
 
@@ -18,10 +17,7 @@ describe('RoomRepository', () => {
       softDelete: jest.fn(),
     };
 
-    roomRepository = new RoomRepository(
-      roomOrmRepository as Repository<Room>,
-      {} as Repository<RoomMember>,
-    );
+    roomRepository = new RoomRepository(roomOrmRepository as Repository<Room>);
   });
 
   describe('findRoomFilter', () => {

--- a/src/rooms/room.repository.ts
+++ b/src/rooms/room.repository.ts
@@ -3,8 +3,7 @@ import { CreateRoomDto } from './dto/create-room.dto';
 import { FindRoomsQueryDto } from './dto/find-rooms-query.dto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { RoomMember } from './entities/room-member.entity';
-import { Room, RoomStatus } from './entities/room.entity';
+import { Room, RoomStatus, RoomType } from './entities/room.entity';
 import {
   Between,
   DeleteResult,
@@ -17,14 +16,13 @@ import {
   UpdateResult,
 } from 'typeorm';
 import { PAGINATION_CONSTANTS } from './constants/room.constant';
+import { UserConditionsParam } from './types/room.type';
 
 @Injectable()
 export class RoomRepository {
   constructor(
     @InjectRepository(Room)
     private readonly roomRepository: Repository<Room>,
-    @InjectRepository(RoomMember)
-    private readonly roomMemberRepository: Repository<RoomMember>,
   ) {}
 
   async createRoom(
@@ -103,6 +101,23 @@ export class RoomRepository {
         status: RoomStatus.OPEN,
       },
     });
+  }
+
+  async findJoinableRooms(
+    userConditions: UserConditionsParam,
+    manager: EntityManager,
+  ): Promise<Room[]> {
+    return await manager
+      .createQueryBuilder(Room, 'room')
+      .where('room.status = :status', { status: RoomStatus.OPEN })
+      .andWhere('(room.roomType = :type OR room.roomType = :any)', {
+        type: RoomType[userConditions.gender],
+        any: RoomType.ANY,
+      })
+      .andWhere('room.maxAge >= :age', { age: userConditions.age })
+      .andWhere('room.minAge <= :age', { age: userConditions.age })
+      .andWhere('room.currentMembersCount < room.maxMembersCount')
+      .getMany();
   }
 
   async updateRoom(roomId: number, updateRoomDto: UpdateRoomDto): Promise<UpdateResult> {

--- a/src/rooms/room.service.spec.ts
+++ b/src/rooms/room.service.spec.ts
@@ -100,6 +100,7 @@ const mockRoomRepository = {
   createRoom: jest.fn(),
   findRoomById: jest.fn(),
   findRooms: jest.fn(),
+  findJoinableRooms: jest.fn(),
   updateRoom: jest.fn(),
   deleteRoom: jest.fn(),
   increaseCurrentMembersCount: jest.fn(),
@@ -291,6 +292,7 @@ describe('RoomService', () => {
       expect(result).toEqual(mockRoomDetailDto);
       expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
         mockUserSummary.id,
+        undefined,
       );
       expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
       expect(roomMapperSpy).toHaveBeenCalledWith(mockRoomEntity);
@@ -404,6 +406,7 @@ describe('RoomService', () => {
 
       expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
         mockUserSummary.id,
+        undefined,
       );
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
@@ -420,6 +423,7 @@ describe('RoomService', () => {
 
       expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
         mockUserSummary.id,
+        undefined,
       );
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
@@ -609,6 +613,7 @@ describe('RoomService', () => {
       expect(mockRoomRepository.findRoomById).toHaveBeenCalledWith(mockRoomEntity.id);
       expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
         mockUserSummary.id,
+        undefined,
       );
       expect(mockRoomMemberService.findRoomMemberCount).toHaveBeenCalledWith(
         mockManager,
@@ -676,6 +681,81 @@ describe('RoomService', () => {
       );
 
       expect(mockDataSource.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('quickJoin', () => {
+    const mockCurrentUser = {
+      id: mockUserSummary.id,
+      email: 'test@gmail.com',
+      nickname: mockUserSummary.nickname,
+      gender: 'MALE' as const,
+      birthDate: '2005-01-01',
+      schoolInfo: mockUserSummary.schoolInfo,
+    };
+
+    it('조건에 맞는 방 중 하나를 골라 빠르게 참여', async () => {
+      const anotherRoom = {
+        ...mockRoomEntity,
+        id: 2,
+      };
+      const newMember = {
+        id: 10,
+        room: { id: anotherRoom.id },
+        user: { id: mockUserSummary.id },
+      };
+      jest.spyOn(Math, 'random').mockReturnValueOnce(0.9);
+
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
+      mockRoomRepository.findJoinableRooms.mockResolvedValueOnce([mockRoomEntity, anotherRoom]);
+      mockRoomMemberService.findRoomMemberCount.mockResolvedValueOnce(1);
+      mockRoomRepository.increaseCurrentMembersCount.mockResolvedValueOnce(undefined);
+      mockRoomMemberService.joinRoom.mockResolvedValueOnce(newMember);
+
+      const result = await roomService.quickJoin(mockUserSummary.id);
+
+      expect(result).toEqual(newMember);
+      expect(mockUserService.findMe).toHaveBeenCalledWith(mockUserSummary.id);
+      expect(mockRoomMemberService.findParticipatingRoomByUserId).toHaveBeenCalledWith(
+        mockUserSummary.id,
+        mockManager,
+      );
+      expect(mockRoomRepository.findJoinableRooms).toHaveBeenCalledWith(
+        {
+          age: 22,
+          gender: 'MALE',
+        },
+        mockManager,
+      );
+      expect(mockRoomMemberService.findRoomMemberCount).toHaveBeenCalledWith(mockManager, 2);
+      expect(mockRoomRepository.increaseCurrentMembersCount).toHaveBeenCalledWith(mockManager, 2);
+      expect(mockRoomMemberService.joinRoom).toHaveBeenCalledWith(
+        mockManager,
+        2,
+        mockUserSummary.id,
+      );
+    });
+
+    it('이미 참여 중인 방이 있으면 BadRequestException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce({ id: 123 });
+
+      await expect(roomService.quickJoin(mockUserSummary.id)).rejects.toThrow(BadRequestException);
+
+      expect(mockRoomRepository.findJoinableRooms).not.toHaveBeenCalled();
+      expect(mockRoomRepository.increaseCurrentMembersCount).not.toHaveBeenCalled();
+    });
+
+    it('참여 가능한 방이 없으면 NotFoundException을 반환', async () => {
+      mockUserService.findMe.mockResolvedValueOnce(mockCurrentUser);
+      mockRoomMemberService.findParticipatingRoomByUserId.mockResolvedValueOnce(null);
+      mockRoomRepository.findJoinableRooms.mockResolvedValueOnce([]);
+
+      await expect(roomService.quickJoin(mockUserSummary.id)).rejects.toThrow(NotFoundException);
+
+      expect(mockRoomRepository.findJoinableRooms).toHaveBeenCalled();
+      expect(mockRoomRepository.increaseCurrentMembersCount).not.toHaveBeenCalled();
     });
   });
 

--- a/src/rooms/roomMember.repository.ts
+++ b/src/rooms/roomMember.repository.ts
@@ -22,8 +22,11 @@ export class RoomMemberRepository {
     });
   }
 
-  async findParticipatingRoomByUserId(userId: number): Promise<RoomMember | null> {
-    return await this.roomMemberRepository.findOne({
+  async findParticipatingRoomByUserId(
+    userId: number,
+    manager?: EntityManager,
+  ): Promise<RoomMember | null> {
+    const queryOptions = {
       where: {
         user: { id: userId },
         room: { status: RoomStatus.OPEN },
@@ -39,11 +42,14 @@ export class RoomMemberRepository {
       order: {
         room: {
           roomMembers: {
-            createdAt: 'ASC',
+            createdAt: 'ASC' as const,
           },
         },
       },
-    });
+    };
+
+    if (manager) return await manager.findOne(RoomMember, queryOptions);
+    return await this.roomMemberRepository.findOne(queryOptions);
   }
 
   async findRoomMembersByRoomId(roomId: number): Promise<RoomMember[]> {

--- a/src/rooms/roomMember.service.ts
+++ b/src/rooms/roomMember.service.ts
@@ -18,8 +18,8 @@ export class RoomMemberService {
     return await this.roomMemberRepository.findRoomMemberCount(manager, roomId);
   }
 
-  async findParticipatingRoomByUserId(userId: number) {
-    return await this.roomMemberRepository.findParticipatingRoomByUserId(userId);
+  async findParticipatingRoomByUserId(userId: number, manager?: EntityManager) {
+    return await this.roomMemberRepository.findParticipatingRoomByUserId(userId, manager);
   }
 
   async createRoomMember(

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -212,4 +212,16 @@ export class RoomController {
   ): Promise<ResponseRoomMemberListDto> {
     return await this.roomService.findRoomMembersByRoomId(roomId);
   }
+
+  @Post('quick-join')
+  @Authenticated()
+  @HttpCode(201)
+  @ApiOperation({ summary: '빠른 참여' })
+  @ApiCreatedResponse({ description: '사용자 조건에 맞는 방에 빠르게 참여 성공' })
+  @ApiBadRequestResponse({ description: '이미 참여 중인 방이 있는 경우' })
+  @ApiNotFoundResponse({ description: '참여 가능한 방이 없는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async quickJoin(@CurrentUser() user: AuthenticatedUser): Promise<RoomMember> {
+    return await this.roomService.quickJoin(user.userId);
+  }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -23,6 +23,7 @@ import { Room, RoomStatus, RoomType } from './entities/room.entity';
 import { calculateAge } from 'src/commons/utils/age.util';
 import { RoomMember } from './entities/room-member.entity';
 import { MeUserResponseDto } from 'src/users/dto/me-user-response.dto';
+import { UserConditionsParam } from './types/room.type';
 
 @Injectable()
 export class RoomService {
@@ -101,6 +102,18 @@ export class RoomService {
     return RoomMapper.toDetailDto(room.room);
   }
 
+  async findJoinableRoomsOrThrow(user: MeUserResponseDto, manager: EntityManager) {
+    const userConditions: UserConditionsParam = {
+      age: calculateAge(user.birthDate),
+      gender: user.gender,
+    };
+
+    const rooms = await this.roomRepository.findJoinableRooms(userConditions, manager);
+    if (rooms.length < 1) throw new NotFoundException('현재 참여할 수 있는 방이 없습니다.');
+
+    return rooms;
+  }
+
   async updateRoom(
     roomId: number,
     updateRoomDto: UpdateRoomDto,
@@ -146,6 +159,21 @@ export class RoomService {
     return await this.joinRoomTransaction(existingRoom, userId);
   }
 
+  async quickJoin(userId: number): Promise<RoomMember> {
+    const user = await this.userService.findMe(userId);
+
+    return await this.dataSource.transaction(async (manager) => {
+      await this.validateParticipatingRoom(userId, manager);
+
+      const rooms = await this.findJoinableRoomsOrThrow(user, manager);
+      const roomsCount = rooms.length;
+      const randomNum = Math.floor(Math.random() * roomsCount);
+      const randomRoom = rooms[randomNum];
+
+      return await this.joinRoomAndIncreaseMemberCount(manager, randomRoom, userId);
+    });
+  }
+
   async leaveRoom(roomId: number, userId: number): Promise<void> {
     const existingRoom = await this.findExistingRoomOrThrow(roomId);
 
@@ -163,13 +191,17 @@ export class RoomService {
 
   async joinRoomTransaction(room: Room, userId: number): Promise<RoomMember> {
     return await this.dataSource.transaction(async (manager) => {
-      const memberCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
-      if (room.maxMembersCount <= memberCount)
-        throw new BadRequestException('방 인원이 가득 차 참여할 수 없습니다.');
-
-      await this.roomRepository.increaseCurrentMembersCount(manager, room.id);
-      return await this.roomMemberService.joinRoom(manager, room.id, userId);
+      return this.joinRoomAndIncreaseMemberCount(manager, room, userId);
     });
+  }
+
+  async joinRoomAndIncreaseMemberCount(manager: EntityManager, room: Room, userId: number) {
+    const membersCount = await this.roomMemberService.findRoomMemberCount(manager, room.id);
+    if (room.maxMembersCount <= membersCount)
+      throw new BadRequestException('방 인원이 가득 차 참여할 수 없습니다.');
+
+    await this.roomRepository.increaseCurrentMembersCount(manager, room.id);
+    return await this.roomMemberService.joinRoom(manager, room.id, userId);
   }
 
   async leaveRoomTransaction(room: Room, userId: number): Promise<void> {
@@ -248,8 +280,11 @@ export class RoomService {
       throw new BadRequestException('사용자 정보가 방 조건에 맞지 않습니다.');
   }
 
-  async validateParticipatingRoom(userId: number): Promise<void> {
-    const participatingRoom = await this.roomMemberService.findParticipatingRoomByUserId(userId);
+  async validateParticipatingRoom(userId: number, manager?: EntityManager): Promise<void> {
+    const participatingRoom = await this.roomMemberService.findParticipatingRoomByUserId(
+      userId,
+      manager,
+    );
     if (participatingRoom) throw new BadRequestException('이미 참여 중인 방이 있습니다.');
   }
 

--- a/src/rooms/types/room.type.ts
+++ b/src/rooms/types/room.type.ts
@@ -1,0 +1,4 @@
+export type UserConditionsParam = {
+  age: number;
+  gender: 'MALE' | 'FEMALE';
+};

--- a/test/rooms-join-leave.e2e-spec.ts
+++ b/test/rooms-join-leave.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import { Room } from '../src/rooms/entities/room.entity';
+import { Room, RoomType } from '../src/rooms/entities/room.entity';
 import { RoomMember } from '../src/rooms/entities/room-member.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -80,6 +80,76 @@ describe('Rooms Join/Leave (e2e)', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe('이미 참여 중인 방이 있습니다.');
+  });
+
+  it('POST /rooms/quick-join 조건에 맞는 방에 빠르게 참여', async () => {
+    const hostOneSignupResponse = await signupUser(httpApp, 'quick-host-1@gmail.com', '빠른방장1');
+    const hostTwoSignupResponse = await signupUser(httpApp, 'quick-host-2@gmail.com', '빠른방장2');
+    const guestSignupResponse = await signupUser(httpApp, 'quick-user@gmail.com', '빠른참여자');
+    const hostOne = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostOneSignupResponse.body.user.id,
+    });
+    const hostTwo = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostTwoSignupResponse.body.user.id,
+    });
+    const firstRoom = await createRoomFixture(dataSource, hostOne, {
+      title: '빠른 참여 후보 1',
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+    const secondRoom = await createRoomFixture(dataSource, hostTwo, {
+      title: '빠른 참여 후보 2',
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    const response = await request(httpApp())
+      .post('/rooms/quick-join')
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(201);
+
+    const joinedMember = await dataSource.getRepository(RoomMember).findOne({
+      where: {
+        user: { id: guestSignupResponse.body.user.id },
+      },
+      relations: {
+        room: true,
+      },
+    });
+
+    expect(joinedMember).not.toBeNull();
+    expect([firstRoom.id, secondRoom.id]).toContain(joinedMember!.room.id);
+
+    const joinedRoom = await dataSource.getRepository(Room).findOneByOrFail({
+      id: joinedMember!.room.id,
+    });
+
+    expect(joinedRoom.currentMembersCount).toBe(2);
+  });
+
+  it('POST /rooms/quick-join 참여 가능한 방이 없으면 실패', async () => {
+    const hostSignupResponse = await signupUser(httpApp, 'quick-no-room-host@gmail.com', '여성방장');
+    const guestSignupResponse = await signupUser(httpApp, 'quick-no-room-user@gmail.com', '남성유저');
+    const hostUser = await dataSource.getRepository(User).findOneByOrFail({
+      id: hostSignupResponse.body.user.id,
+    });
+
+    await createRoomFixture(dataSource, hostUser, {
+      roomType: RoomType.FEMALE,
+      currentMembersCount: 1,
+      minAge: 20,
+      maxAge: 30,
+    });
+
+    const response = await request(httpApp())
+      .post('/rooms/quick-join')
+      .set('Authorization', `Bearer ${guestSignupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('현재 참여할 수 있는 방이 없습니다.');
   });
 
   it('DELETE /rooms/:id/leave 참여 중인 사용자가 방에서 나감', async () => {


### PR DESCRIPTION
## 연관된 이슈

- #97 

## 📝 작업 내용

- [x] `POST /rooms/quick-join` 빠른 참여 API 구현
- [x] `RoomController`에 빠른 참여 엔드포인트 추가
- [x] 빠른 참여 Swagger 문서화 추가
- [x] 이미 참여 중인 사용자인지 검증 추가
- [x] 사용자 정보 조회 로직 연결
- [x] 사용자 조건에 맞는 참여 가능한 방 후보 조회 로직 구현
- [x] `OPEN` 상태 방만 후보에 포함되도록 처리
- [x] 정원이 가득 차지 않은 방만 후보에 포함되도록 처리
- [x] 사용자 성별 조건에 맞는 방만 후보에 포함되도록 처리
- [x] 사용자 나이 조건에 맞는 방만 후보에 포함되도록 처리
- [x] 참여 가능한 방이 없을 때 예외 처리 추가
- [x] 후보 방 중 랜덤 선택 로직 구현
- [x] 빠른 참여 시 멤버 수 증가 및 참여 처리 공통 함수로 분리
- [x] 최종 참여 직전 정원 재검증 로직 반영
- [x] `RoomRepository` 빠른 참여 로직 구현
- [x] 빠른 참여 테스트 추가