### PR TITLE
Auth User Friend 예외 메시지 기준 정리

### DIFF
--- a/src/friends/dto/get-friend-list-query.dto.ts
+++ b/src/friends/dto/get-friend-list-query.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsIn, IsOptional, IsString } from 'class-validator';
+import { FRIEND_ERROR_MESSAGES } from '../friend.constants';
 
 export class GetFriendListQueryDto {
   @ApiPropertyOptional({
@@ -9,6 +10,6 @@ export class GetFriendListQueryDto {
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
   @IsString()
-  @IsIn(['accepted'])
+  @IsIn(['accepted'], { message: FRIEND_ERROR_MESSAGES.acceptedStatusOnly })
   status?: 'accepted';
 }

--- a/src/friends/friend.constants.ts
+++ b/src/friends/friend.constants.ts
@@ -1,0 +1,13 @@
+export const FRIEND_ERROR_MESSAGES = {
+  cannotRequestSelf: 'Cannot send friend request to yourself.',
+  requestNotFound: 'Friend request not found.',
+  requestAlreadyExists: 'Friend request already exists.',
+  reversePendingExists: 'Friend request from the target user already exists.',
+  alreadyFriends: 'Already friends.',
+  receiverOnly: 'Only the receiver can process this request.',
+  requesterOnly: 'Only the requester can cancel this request.',
+  alreadyProcessed: 'Friend request has already been processed.',
+  acceptedOnly: 'Only accepted friends can be deleted.',
+  relatedUsersOnly: 'Only related users can delete this friendship.',
+  acceptedStatusOnly: 'Only status=accepted is supported.',
+} as const;

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { UserService } from '../users/users.service';
+import { FRIEND_ERROR_MESSAGES } from './friend.constants';
 import { Friend, FriendStatus } from './entities/friend.entity';
 import { FriendRepository } from './friends.repository';
 
@@ -71,7 +72,7 @@ export class FriendService {
 
   private async validateReceiver(requesterId: number, receiverId: number): Promise<void> {
     if (requesterId === receiverId) {
-      throw new BadRequestException('Cannot send friend request to yourself.');
+      throw new BadRequestException(FRIEND_ERROR_MESSAGES.cannotRequestSelf);
     }
 
     await this.userService.findActiveUserOrFail(receiverId);
@@ -88,7 +89,7 @@ export class FriendService {
     );
 
     if (sameDirectionRelation) {
-      throw new ConflictException('Friend request already exists.');
+      throw new ConflictException(FRIEND_ERROR_MESSAGES.requestAlreadyExists);
     }
 
     const reverseRelation = existingRelations.find(
@@ -96,11 +97,11 @@ export class FriendService {
     );
 
     if (reverseRelation?.status === FriendStatus.PENDING) {
-      throw new ConflictException('Friend request from the target user already exists.');
+      throw new ConflictException(FRIEND_ERROR_MESSAGES.reversePendingExists);
     }
 
     if (reverseRelation?.status === FriendStatus.ACCEPTED) {
-      throw new ConflictException('Already friends.');
+      throw new ConflictException(FRIEND_ERROR_MESSAGES.alreadyFriends);
     }
   }
 
@@ -108,7 +109,7 @@ export class FriendService {
     const friendRequest = await this.friendRepository.findById(friendshipId);
 
     if (!friendRequest) {
-      throw new NotFoundException('Friend request not found.');
+      throw new NotFoundException(FRIEND_ERROR_MESSAGES.requestNotFound);
     }
 
     return friendRequest;
@@ -116,37 +117,37 @@ export class FriendService {
 
   private ensureReceiverOwnsRequest(friendRequest: Friend, currentUserId: number): void {
     if (friendRequest.receiver.id !== currentUserId) {
-      throw new ForbiddenException('Only the receiver can process this request.');
+      throw new ForbiddenException(FRIEND_ERROR_MESSAGES.receiverOnly);
     }
   }
 
   private ensureRequesterOwnsRequest(friendRequest: Friend, currentUserId: number): void {
     if (friendRequest.requester.id !== currentUserId) {
-      throw new ForbiddenException('Only the requester can cancel this request.');
+      throw new ForbiddenException(FRIEND_ERROR_MESSAGES.requesterOnly);
     }
   }
 
   private ensurePendingRequest(friendRequest: Friend): void {
     if (friendRequest.status !== FriendStatus.PENDING) {
-      throw new ConflictException('Friend request has already been processed.');
+      throw new ConflictException(FRIEND_ERROR_MESSAGES.alreadyProcessed);
     }
   }
 
   private ensureAcceptedFriend(friend: Friend): void {
     if (friend.status !== FriendStatus.ACCEPTED) {
-      throw new ConflictException('Only accepted friends can be deleted.');
+      throw new ConflictException(FRIEND_ERROR_MESSAGES.acceptedOnly);
     }
   }
 
   private ensureUserRelatedToFriend(friend: Friend, currentUserId: number): void {
     if (friend.requester.id !== currentUserId && friend.receiver.id !== currentUserId) {
-      throw new ForbiddenException('Only related users can delete this friendship.');
+      throw new ForbiddenException(FRIEND_ERROR_MESSAGES.relatedUsersOnly);
     }
   }
 
   private validateFriendListStatus(status?: 'accepted'): void {
     if (status && status !== 'accepted') {
-      throw new BadRequestException('Only status=accepted is supported.');
+      throw new BadRequestException(FRIEND_ERROR_MESSAGES.acceptedStatusOnly);
     }
   }
 }

--- a/src/users/user.constants.ts
+++ b/src/users/user.constants.ts
@@ -1,0 +1,5 @@
+export const USER_ERROR_MESSAGES = {
+  userNotFound: 'User not found.',
+  emailAlreadyExists: 'Email already exists.',
+  nicknameAlreadyExists: 'Nickname already exists.',
+} as const;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { User } from './entities/user.entity';
 import { UpdateMeDto } from './dto/update-me.dto';
+import { USER_ERROR_MESSAGES } from './user.constants';
 import { UpdateMePatch, UserRepository } from './users.repository';
 
 @Injectable()
@@ -27,7 +28,7 @@ export class UserService {
     const existingUser = await this.userRepository.existsByEmail(email);
 
     if (existingUser) {
-      throw new ConflictException('Email already exists.');
+      throw new ConflictException(USER_ERROR_MESSAGES.emailAlreadyExists);
     }
   }
 
@@ -37,7 +38,7 @@ export class UserService {
       : await this.userRepository.existsByNickname(nickname);
 
     if (existingUser) {
-      throw new ConflictException('Nickname already exists.');
+      throw new ConflictException(USER_ERROR_MESSAGES.nicknameAlreadyExists);
     }
   }
 
@@ -77,7 +78,7 @@ export class UserService {
     const user = await this.userRepository.findActiveUserById(userId);
 
     if (!user) {
-      throw new NotFoundException('User not found.');
+      throw new NotFoundException(USER_ERROR_MESSAGES.userNotFound);
     }
 
     return user;

--- a/test/auth-users.e2e-spec.ts
+++ b/test/auth-users.e2e-spec.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AUTH_ERROR_MESSAGES } from '../src/auth/auth.constants';
+import { USER_ERROR_MESSAGES } from '../src/users/user.constants';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
 
@@ -88,7 +89,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expectExceptionFilterErrorResponse(response, 409, 'Email already exists.');
+    expectExceptionFilterErrorResponse(response, 409, USER_ERROR_MESSAGES.emailAlreadyExists);
   });
 
   it('닉네임 중복 회원가입 실패', async () => {
@@ -110,7 +111,7 @@ describe('Auth and Users (e2e)', () => {
       schoolInfo: 'Yonsei University',
     });
 
-    expectExceptionFilterErrorResponse(response, 409, 'Nickname already exists.');
+    expectExceptionFilterErrorResponse(response, 409, USER_ERROR_MESSAGES.nicknameAlreadyExists);
   });
 
   it('로그인 성공', async () => {
@@ -381,7 +382,7 @@ describe('Auth and Users (e2e)', () => {
         nickname: 'taken-nickname',
       });
 
-    expectExceptionFilterErrorResponse(response, 409, 'Nickname already exists.');
+    expectExceptionFilterErrorResponse(response, 409, USER_ERROR_MESSAGES.nicknameAlreadyExists);
   });
 
   it('DELETE /users/me 후 soft delete 반영 및 재로그인 실패', async () => {

--- a/test/friend-delete.e2e-spec.ts
+++ b/test/friend-delete.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend Delete (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -118,7 +132,7 @@ describe('Friend Delete (e2e)', () => {
       .delete(`/friends/${pendingFriendship.id}`)
       .set('Authorization', `Bearer ${firstUser.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.acceptedOnly);
   });
 
   it('권한 없는 사용자 삭제 시 403', async () => {
@@ -145,6 +159,6 @@ describe('Friend Delete (e2e)', () => {
       .delete(`/friends/${friendship.id}`)
       .set('Authorization', `Bearer ${thirdUser.body.accessToken}`);
 
-    expect(response.status).toBe(403);
+    expectExceptionFilterErrorResponse(response, 403, FRIEND_ERROR_MESSAGES.relatedUsersOnly);
   });
 });

--- a/test/friend-list.e2e-spec.ts
+++ b/test/friend-list.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend List (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -214,7 +228,7 @@ describe('Friend List (e2e)', () => {
       .get('/friends')
       .query({ status: 'accepted' });
 
-    expect(response.status).toBe(401);
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 
   it('status=accepted 는 성공', async () => {
@@ -242,6 +256,6 @@ describe('Friend List (e2e)', () => {
       .set('Authorization', `Bearer ${currentUser.body.accessToken}`)
       .query({ status: 'pending' });
 
-    expect(response.status).toBe(400);
+    expectExceptionFilterErrorResponse(response, 400, [FRIEND_ERROR_MESSAGES.acceptedStatusOnly]);
   });
 });

--- a/test/friend-request-accept.e2e-spec.ts
+++ b/test/friend-request-accept.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend Request Accept (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -99,13 +113,13 @@ describe('Friend Request Accept (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/accept`)
       .set('Authorization', `Bearer ${requester.body.accessToken}`);
 
-    expect(requesterResponse.status).toBe(403);
+    expectExceptionFilterErrorResponse(requesterResponse, 403, FRIEND_ERROR_MESSAGES.receiverOnly);
 
     const thirdUserResponse = await request(app.getHttpServer())
       .patch(`/friends/requests/${friendRequest.body.id}/accept`)
       .set('Authorization', `Bearer ${thirdUser.body.accessToken}`);
 
-    expect(thirdUserResponse.status).toBe(403);
+    expectExceptionFilterErrorResponse(thirdUserResponse, 403, FRIEND_ERROR_MESSAGES.receiverOnly);
   });
 
   it('존재하지 않는 친구 요청 수락 시 404', async () => {
@@ -118,7 +132,7 @@ describe('Friend Request Accept (e2e)', () => {
       .patch('/friends/requests/999999/accept')
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(404);
+    expectExceptionFilterErrorResponse(response, 404, FRIEND_ERROR_MESSAGES.requestNotFound);
   });
 
   it('이미 ACCEPTED 인 요청 재수락 시 409', async () => {
@@ -132,7 +146,7 @@ describe('Friend Request Accept (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/accept`)
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('이미 REJECTED 인 요청 재수락 시 409', async () => {
@@ -146,7 +160,7 @@ describe('Friend Request Accept (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/accept`)
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('인증 없이 친구 신청 수락 시 401', async () => {
@@ -156,6 +170,6 @@ describe('Friend Request Accept (e2e)', () => {
       `/friends/requests/${friendRequest.body.id}/accept`,
     );
 
-    expect(response.status).toBe(401);
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 });

--- a/test/friend-request-cancel.e2e-spec.ts
+++ b/test/friend-request-cancel.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend Request Cancel (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -107,7 +121,7 @@ describe('Friend Request Cancel (e2e)', () => {
       .delete(`/friends/requests/${friendRequest.body.id}`)
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(403);
+    expectExceptionFilterErrorResponse(response, 403, FRIEND_ERROR_MESSAGES.requesterOnly);
   });
 
   it('제3자 취소 시도 시 403', async () => {
@@ -121,7 +135,7 @@ describe('Friend Request Cancel (e2e)', () => {
       .delete(`/friends/requests/${friendRequest.body.id}`)
       .set('Authorization', `Bearer ${thirdUser.body.accessToken}`);
 
-    expect(response.status).toBe(403);
+    expectExceptionFilterErrorResponse(response, 403, FRIEND_ERROR_MESSAGES.requesterOnly);
   });
 
   it('존재하지 않는 요청 취소 시 404', async () => {
@@ -134,7 +148,7 @@ describe('Friend Request Cancel (e2e)', () => {
       .delete('/friends/requests/999999')
       .set('Authorization', `Bearer ${requester.body.accessToken}`);
 
-    expect(response.status).toBe(404);
+    expectExceptionFilterErrorResponse(response, 404, FRIEND_ERROR_MESSAGES.requestNotFound);
   });
 
   it('이미 ACCEPTED 요청 취소 시 409', async () => {
@@ -148,7 +162,7 @@ describe('Friend Request Cancel (e2e)', () => {
       .delete(`/friends/requests/${friendRequest.body.id}`)
       .set('Authorization', `Bearer ${requester.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('이미 REJECTED 요청 취소 시 409', async () => {
@@ -162,7 +176,7 @@ describe('Friend Request Cancel (e2e)', () => {
       .delete(`/friends/requests/${friendRequest.body.id}`)
       .set('Authorization', `Bearer ${requester.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('인증 없이 취소 시 401', async () => {
@@ -172,7 +186,7 @@ describe('Friend Request Cancel (e2e)', () => {
       `/friends/requests/${friendRequest.body.id}`,
     );
 
-    expect(response.status).toBe(401);
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 
   it('취소 후 같은 방향 재신청이 다시 가능함', async () => {

--- a/test/friend-request-reject.e2e-spec.ts
+++ b/test/friend-request-reject.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend Request Reject (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -99,13 +113,13 @@ describe('Friend Request Reject (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/reject`)
       .set('Authorization', `Bearer ${requester.body.accessToken}`);
 
-    expect(requesterResponse.status).toBe(403);
+    expectExceptionFilterErrorResponse(requesterResponse, 403, FRIEND_ERROR_MESSAGES.receiverOnly);
 
     const thirdUserResponse = await request(app.getHttpServer())
       .patch(`/friends/requests/${friendRequest.body.id}/reject`)
       .set('Authorization', `Bearer ${thirdUser.body.accessToken}`);
 
-    expect(thirdUserResponse.status).toBe(403);
+    expectExceptionFilterErrorResponse(thirdUserResponse, 403, FRIEND_ERROR_MESSAGES.receiverOnly);
   });
 
   it('존재하지 않는 친구 요청 거절 시 404', async () => {
@@ -118,7 +132,7 @@ describe('Friend Request Reject (e2e)', () => {
       .patch('/friends/requests/999999/reject')
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(404);
+    expectExceptionFilterErrorResponse(response, 404, FRIEND_ERROR_MESSAGES.requestNotFound);
   });
 
   it('이미 REJECTED 인 요청 재거절 시 409', async () => {
@@ -132,7 +146,7 @@ describe('Friend Request Reject (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/reject`)
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('이미 ACCEPTED 인 요청 재거절 시 409', async () => {
@@ -146,7 +160,7 @@ describe('Friend Request Reject (e2e)', () => {
       .patch(`/friends/requests/${friendRequest.body.id}/reject`)
       .set('Authorization', `Bearer ${receiver.body.accessToken}`);
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyProcessed);
   });
 
   it('인증 없이 친구 신청 거절 시 401', async () => {
@@ -156,6 +170,6 @@ describe('Friend Request Reject (e2e)', () => {
       `/friends/requests/${friendRequest.body.id}/reject`,
     );
 
-    expect(response.status).toBe(401);
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 });

--- a/test/friend-request.e2e-spec.ts
+++ b/test/friend-request.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
@@ -25,6 +26,19 @@ describe('Friend Request (e2e)', () => {
     await dataSource.createQueryBuilder().delete().from(Friend).execute();
     await dataSource.createQueryBuilder().delete().from(User).execute();
   });
+
+  function expectExceptionFilterErrorResponse(
+    response: request.Response,
+    statusCode: number,
+    message: string,
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
 
   async function signupUser(params: {
     email: string;
@@ -99,7 +113,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: user.body.user.id,
       });
 
-    expect(response.status).toBe(400);
+    expectExceptionFilterErrorResponse(response, 400, FRIEND_ERROR_MESSAGES.cannotRequestSelf);
   });
 
   it('존재하지 않는 사용자에게 신청 시 404', async () => {
@@ -115,7 +129,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: 999999,
       });
 
-    expect(response.status).toBe(404);
+    expectExceptionFilterErrorResponse(response, 404, 'User not found.');
   });
 
   it('동일 방향 중복 신청 시 409', async () => {
@@ -142,7 +156,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: receiver.body.user.id,
       });
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.requestAlreadyExists);
   });
 
   it('반대 방향 pending 관계가 있으면 409', async () => {
@@ -169,7 +183,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: secondUser.body.user.id,
       });
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.reversePendingExists);
   });
 
   it('이미 친구인 경우 409', async () => {
@@ -195,7 +209,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: receiver.body.user.id,
       });
 
-    expect(response.status).toBe(409);
+    expectExceptionFilterErrorResponse(response, 409, FRIEND_ERROR_MESSAGES.alreadyFriends);
   });
 
   it('인증 없이 친구 신청 시 401', async () => {
@@ -208,6 +222,6 @@ describe('Friend Request (e2e)', () => {
       receiverId: receiver.body.user.id,
     });
 
-    expect(response.status).toBe(401);
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
   });
 });


### PR DESCRIPTION
## 연관된 이슈

- #89

## 📝 작업 내용

- [x] Auth의 상수 기반 에러 메시지 구조와 User/Friend의 인라인 메시지 구조 비교 정리
- [x] 도메인별 예외 메시지 관리 기준 수립
- [x] 필요 시 공통 상수화 또는 도메인별 정책 분리 기준 문서화
- [x] 테스트에서 검증 가능한 `statusCode`와 `message` 기준 정리
