### PR TITLE
Friend Repository Query 기준 정리

### DIFF
--- a/src/friends/friends.repository.ts
+++ b/src/friends/friends.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { Friend, FriendStatus } from './entities/friend.entity';
 
@@ -12,10 +12,8 @@ export class FriendRepository {
   ) {}
 
   async findActiveRelationsBetweenUsers(userId: number, otherUserId: number): Promise<Friend[]> {
-    return this.friendRepository
-      .createQueryBuilder('friend')
-      .leftJoinAndSelect('friend.requester', 'requester')
-      .leftJoinAndSelect('friend.receiver', 'receiver')
+    // Bidirectional requester/receiver matching still needs query builder.
+    return this.createRelationQuery()
       .where(
         '(requester.id = :userId AND receiver.id = :otherUserId) OR (requester.id = :otherUserId AND receiver.id = :userId)',
         { userId, otherUserId },
@@ -24,21 +22,16 @@ export class FriendRepository {
   }
 
   async findAcceptedRelationsForUser(userId: number): Promise<Friend[]> {
-    return this.friendRepository
-      .createQueryBuilder('friend')
-      .leftJoinAndSelect('friend.requester', 'requester')
-      .leftJoinAndSelect('friend.receiver', 'receiver')
+    // Friend list lookup combines joined users with OR filtering on both sides.
+    return this.createRelationQuery()
       .where('(requester.id = :userId OR receiver.id = :userId)', { userId })
       .andWhere('friend.status = :status', { status: FriendStatus.ACCEPTED })
       .getMany();
   }
 
   async findRestorableRequest(requesterId: number, receiverId: number): Promise<Friend | null> {
-    return this.friendRepository
-      .createQueryBuilder('friend')
-      .withDeleted()
-      .leftJoinAndSelect('friend.requester', 'requester')
-      .leftJoinAndSelect('friend.receiver', 'receiver')
+    // Restorable lookup needs withDeleted plus joined requester/receiver filtering.
+    return this.createRelationQuery({ withDeleted: true })
       .where('requester.id = :requesterId', { requesterId })
       .andWhere('receiver.id = :receiverId', { receiverId })
       .andWhere('friend.deleted_at IS NOT NULL')
@@ -46,12 +39,13 @@ export class FriendRepository {
   }
 
   async findById(friendId: number): Promise<Friend | null> {
-    return this.friendRepository
-      .createQueryBuilder('friend')
-      .leftJoinAndSelect('friend.requester', 'requester')
-      .leftJoinAndSelect('friend.receiver', 'receiver')
-      .where('friend.id = :friendId', { friendId })
-      .getOne();
+    return this.friendRepository.findOne({
+      where: { id: friendId },
+      relations: {
+        requester: true,
+        receiver: true,
+      },
+    });
   }
 
   async createOrRestoreRequest(requesterId: number, receiverId: number): Promise<Friend> {
@@ -87,6 +81,19 @@ export class FriendRepository {
 
   async softDelete(friendId: number): Promise<void> {
     await this.friendRepository.softDelete(friendId);
+  }
+
+  private createRelationQuery(options?: { withDeleted?: boolean }): SelectQueryBuilder<Friend> {
+    const query = this.friendRepository
+      .createQueryBuilder('friend')
+      .leftJoinAndSelect('friend.requester', 'requester')
+      .leftJoinAndSelect('friend.receiver', 'receiver');
+
+    if (options?.withDeleted) {
+      query.withDeleted();
+    }
+
+    return query;
   }
 
   private async persistAndReload(friendRequest: Friend): Promise<Friend> {


### PR DESCRIPTION
## 연관된 이슈

- #90

## 📝 작업 내용

- [x] Friend repository의 query builder 사용 메서드 현황 정리
- [x] `requester`, `receiver` 조인과 양방향 조건 조회가 필요한 메서드는 유지 기준 명시
- [x] `withDeleted` 조회처럼 repository 기본 메서드로 대체가 까다로운 경우는 유지 기준 명시
- [x] `findById`처럼 단순화 가능한 메서드는 `findOne` 계열 전환 여부 검토
- [x] Friend repository의 query 사용 기준을 User/Auth/MealMenu와 비교 가능하도록 문서화
- [x] 리팩토링 후 repository 코드 일관성 정리
