### PR TITLE
MealMenu 반응 저장 및 전환 로직 정리

### DIFF
--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -77,7 +77,11 @@ export class MealMenuRepository {
     });
   }
 
-  async applyLike(userId: number, mealMenuId: number): Promise<MealMenu> {
+  async applyReaction(
+    userId: number,
+    mealMenuId: number,
+    actionType: ActionType,
+  ): Promise<MealMenu> {
     return this.dataSource.transaction(async (manager) => {
       const mealMenuRepository = manager.getRepository(MealMenu);
       const mealMenuReactionRepository = manager.getRepository(MealMenuReaction);
@@ -89,72 +93,81 @@ export class MealMenuRepository {
           mealMenu: { id: mealMenuId },
         },
       });
+      const previousActionType = existingReaction?.actionType;
 
-      if (!existingReaction) {
-        await mealMenuReactionRepository.save(
-          mealMenuReactionRepository.create({
-            actionType: ActionType.LIKE,
-            user: { id: userId } as User,
-            mealMenu: { id: mealMenuId } as MealMenu,
-          }),
-        );
+      await this.persistReaction(
+        mealMenuReactionRepository,
+        existingReaction,
+        userId,
+        mealMenuId,
+        actionType,
+      );
 
-        mealMenu.likeCount += 1;
-      } else if (existingReaction.actionType === ActionType.DISLIKE) {
-        existingReaction.actionType = ActionType.LIKE;
-        await mealMenuReactionRepository.save(existingReaction);
+      const didChangeCounts = this.applyReactionCounts(
+        mealMenu,
+        previousActionType,
+        actionType,
+      );
 
-        mealMenu.likeCount += 1;
-        mealMenu.dislikeCount = Math.max(0, mealMenu.dislikeCount - 1);
+      if (didChangeCounts) {
+        await mealMenuRepository.update(mealMenuId, {
+          likeCount: mealMenu.likeCount,
+          dislikeCount: mealMenu.dislikeCount,
+        });
       }
-
-      await mealMenuRepository.update(mealMenuId, {
-        likeCount: mealMenu.likeCount,
-        dislikeCount: mealMenu.dislikeCount,
-      });
 
       return mealMenu;
     });
   }
 
-  async applyDislike(userId: number, mealMenuId: number): Promise<MealMenu> {
-    return this.dataSource.transaction(async (manager) => {
-      const mealMenuRepository = manager.getRepository(MealMenu);
-      const mealMenuReactionRepository = manager.getRepository(MealMenuReaction);
+  private async persistReaction(
+    repository: Repository<MealMenuReaction>,
+    existingReaction: MealMenuReaction | null,
+    userId: number,
+    mealMenuId: number,
+    actionType: ActionType,
+  ): Promise<void> {
+    if (!existingReaction) {
+      await repository.save(
+        repository.create({
+          actionType,
+          user: { id: userId } as User,
+          mealMenu: { id: mealMenuId } as MealMenu,
+        }),
+      );
+      return;
+    }
 
-      const mealMenu = await mealMenuRepository.findOneByOrFail({ id: mealMenuId });
-      const existingReaction = await mealMenuReactionRepository.findOne({
-        where: {
-          user: { id: userId },
-          mealMenu: { id: mealMenuId },
-        },
-      });
+    if (existingReaction.actionType === actionType) {
+      return;
+    }
 
-      if (!existingReaction) {
-        await mealMenuReactionRepository.save(
-          mealMenuReactionRepository.create({
-            actionType: ActionType.DISLIKE,
-            user: { id: userId } as User,
-            mealMenu: { id: mealMenuId } as MealMenu,
-          }),
-        );
+    existingReaction.actionType = actionType;
+    await repository.save(existingReaction);
+  }
 
-        mealMenu.dislikeCount += 1;
-      } else if (existingReaction.actionType === ActionType.LIKE) {
-        existingReaction.actionType = ActionType.DISLIKE;
-        await mealMenuReactionRepository.save(existingReaction);
+  private applyReactionCounts(
+    mealMenu: MealMenu,
+    previousActionType: ActionType | undefined,
+    nextActionType: ActionType,
+  ): boolean {
+    if (previousActionType === nextActionType) {
+      return false;
+    }
 
-        mealMenu.likeCount = Math.max(0, mealMenu.likeCount - 1);
-        mealMenu.dislikeCount += 1;
-      }
+    if (previousActionType === ActionType.LIKE) {
+      mealMenu.likeCount = Math.max(0, mealMenu.likeCount - 1);
+    } else if (previousActionType === ActionType.DISLIKE) {
+      mealMenu.dislikeCount = Math.max(0, mealMenu.dislikeCount - 1);
+    }
 
-      await mealMenuRepository.update(mealMenuId, {
-        likeCount: mealMenu.likeCount,
-        dislikeCount: mealMenu.dislikeCount,
-      });
+    if (nextActionType === ActionType.LIKE) {
+      mealMenu.likeCount += 1;
+    } else {
+      mealMenu.dislikeCount += 1;
+    }
 
-      return mealMenu;
-    });
+    return true;
   }
 
   private applyReadFilters(

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { GetMealMenuListQueryDto } from './dto/get-meal-menu-list-query.dto';
 import { GetMealMenuRankingQueryDto } from './dto/get-meal-menu-ranking-query.dto';
+import { ActionType } from './entities/meal-menu-reaction.entity';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenuRepository } from './meal-menus.repository';
 
@@ -28,15 +29,21 @@ export class MealMenusService {
   }
 
   async likeMealMenu(userId: number, mealMenuId: number): Promise<MealMenu> {
-    await this.findMealMenuOrFail(mealMenuId);
-
-    return this.mealMenuRepository.applyLike(userId, mealMenuId);
+    return this.applyReactionOrFail(userId, mealMenuId, ActionType.LIKE);
   }
 
   async dislikeMealMenu(userId: number, mealMenuId: number): Promise<MealMenu> {
+    return this.applyReactionOrFail(userId, mealMenuId, ActionType.DISLIKE);
+  }
+
+  private async applyReactionOrFail(
+    userId: number,
+    mealMenuId: number,
+    actionType: ActionType,
+  ): Promise<MealMenu> {
     await this.findMealMenuOrFail(mealMenuId);
 
-    return this.mealMenuRepository.applyDislike(userId, mealMenuId);
+    return this.mealMenuRepository.applyReaction(userId, mealMenuId, actionType);
   }
 
   // Service owns MealMenu domain lookup and state transitions while controllers


### PR DESCRIPTION
## 연관된 이슈

- #92

## 📝 작업 내용

- [x] `applyLike`, `applyDislike`의 중복 저장 및 전환 흐름 정리
- [x] 반응 생성, 반응 전환, 카운트 갱신 책임 분리 기준 정리
- [x] 서비스 레이어의 중복 존재 확인 및 응답 생성 흐름 정리
- [x] 좋아요/싫어요 멱등 정책과 카운트 일관성 유지 검증
- [x] 기존 목록/상세/랭킹 응답 카운트 동작 유지 검증
