### PR TITLE
MealMenu 에러 응답 테스트 정리

### DIFF
--- a/test/meal-menus.e2e-spec.ts
+++ b/test/meal-menus.e2e-spec.ts
@@ -9,6 +9,20 @@ import { createMealMenuAuthTestApp } from './test-app';
 
 jest.setTimeout(30000);
 
+// Assert the error response shape produced by AllExceptionFilter.
+function expectExceptionFilterErrorResponse(
+  response: request.Response,
+  statusCode: number,
+  message: string | string[],
+): void {
+  expect(response.status).toBe(statusCode);
+  expect(response.body.success).toBe(false);
+  expect(response.body.error).toEqual({
+    statusCode,
+    message,
+  });
+}
+
 describe('Meal Menus (e2e)', () => {
   let app: INestApplication<App>;
   let dataSource: DataSource;
@@ -210,7 +224,9 @@ describe('Meal Menus (e2e)', () => {
         .get('/meal-menus')
         .query({ mealType: 'INVALID' });
 
-      expect(response.status).toBe(400);
+      expectExceptionFilterErrorResponse(response, 400, [
+        'mealType must be one of the following values: BREAKFAST, LUNCH, DINNER, ALL',
+      ]);
     });
   });
 
@@ -244,7 +260,7 @@ describe('Meal Menus (e2e)', () => {
     it('존재하지 않는 학식 조회 시 404', async () => {
       const response = await request(app.getHttpServer()).get('/meal-menus/999999');
 
-      expect(response.status).toBe(404);
+      expectExceptionFilterErrorResponse(response, 404, 'Meal menu not found.');
     });
 
     it('soft delete 된 학식 조회 시 404', async () => {
@@ -258,7 +274,7 @@ describe('Meal Menus (e2e)', () => {
 
       const response = await request(app.getHttpServer()).get(`/meal-menus/${mealMenu.id}`);
 
-      expect(response.status).toBe(404);
+      expectExceptionFilterErrorResponse(response, 404, 'Meal menu not found.');
     });
 
     it('인증 없이도 조회 가능', async () => {
@@ -308,7 +324,7 @@ describe('Meal Menus (e2e)', () => {
 
       const response = await request(app.getHttpServer()).post(`/meal-menus/${mealMenu.id}/like`);
 
-      expect(response.status).toBe(401);
+      expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
     });
 
     it('존재하지 않는 학식 좋아요 시 404', async () => {
@@ -318,7 +334,7 @@ describe('Meal Menus (e2e)', () => {
         .post('/meal-menus/999999/like')
         .set('Authorization', `Bearer ${accessToken}`);
 
-      expect(response.status).toBe(404);
+      expectExceptionFilterErrorResponse(response, 404, 'Meal menu not found.');
     });
 
     it('기존 DISLIKE에서 좋아요 호출 시 LIKE로 전환되고 카운트가 교정됨', async () => {
@@ -441,7 +457,7 @@ describe('Meal Menus (e2e)', () => {
         `/meal-menus/${mealMenu.id}/dislike`,
       );
 
-      expect(response.status).toBe(401);
+      expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
     });
 
     it('존재하지 않는 학식 싫어요 시 404', async () => {
@@ -454,7 +470,7 @@ describe('Meal Menus (e2e)', () => {
         .post('/meal-menus/999999/dislike')
         .set('Authorization', `Bearer ${accessToken}`);
 
-      expect(response.status).toBe(404);
+      expectExceptionFilterErrorResponse(response, 404, 'Meal menu not found.');
     });
 
     it('기존 LIKE에서 싫어요 호출 시 DISLIKE로 전환되고 카운트가 교정됨', async () => {
@@ -678,7 +694,9 @@ describe('Meal Menus (e2e)', () => {
     it('actionType 누락 시 400', async () => {
       const response = await request(app.getHttpServer()).get('/meal-menus/rankings');
 
-      expect(response.status).toBe(400);
+      expectExceptionFilterErrorResponse(response, 400, [
+        'actionType must be one of the following values: LIKE, DISLIKE',
+      ]);
     });
 
     it('잘못된 actionType 값 시 400', async () => {
@@ -686,7 +704,9 @@ describe('Meal Menus (e2e)', () => {
         .get('/meal-menus/rankings')
         .query({ actionType: 'INVALID' });
 
-      expect(response.status).toBe(400);
+      expectExceptionFilterErrorResponse(response, 400, [
+        'actionType must be one of the following values: LIKE, DISLIKE',
+      ]);
     });
   });
 });

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -127,6 +127,9 @@ export async function createMealMenuTestApp(): Promise<INestApplication> {
         isGlobal: true,
         ignoreEnvFile: true,
       }),
+      WinstonModule.forRoot({
+        transports: winstonOptions,
+      }),
       TypeOrmModule.forRootAsync({
         useFactory: () => ({
           type: 'postgres',
@@ -159,6 +162,12 @@ export async function createMealMenuTestApp(): Promise<INestApplication> {
       }),
       MealMenuModule,
     ],
+    providers: [
+      {
+        provide: APP_FILTER,
+        useClass: AllExceptionFilter,
+      },
+    ],
   }).compile();
 
   const app = moduleFixture.createNestApplication();
@@ -179,6 +188,9 @@ export async function createMealMenuAuthTestApp(): Promise<INestApplication> {
       ConfigModule.forRoot({
         isGlobal: true,
         ignoreEnvFile: true,
+      }),
+      WinstonModule.forRoot({
+        transports: winstonOptions,
       }),
       TypeOrmModule.forRootAsync({
         useFactory: () => ({
@@ -213,6 +225,12 @@ export async function createMealMenuAuthTestApp(): Promise<INestApplication> {
       UserModule,
       AuthModule,
       MealMenuModule,
+    ],
+    providers: [
+      {
+        provide: APP_FILTER,
+        useClass: AllExceptionFilter,
+      },
     ],
   }).compile();
 


### PR DESCRIPTION
## 연관된 이슈

- #106

## 📝 작업 내용

- [x] `meal-menus.e2e-spec.ts`의 400/401/404 케이스에 에러 응답 shape 검증 추가
- [x] `expectExceptionFilterErrorResponse(...)` 성격의 로컬 helper 도입 여부 정리
- [x] 좋아요/싫어요/상세/랭킹의 실패 응답 메시지 검증 기준 정리
- [x] 기존 목록/상세/랭킹/반응 성공 응답 계약 유지 검증
