### PR TITLE
Friend e2e 에러 응답 테스트 정리

### DIFF
--- a/test/friend-request.e2e-spec.ts
+++ b/test/friend-request.e2e-spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest';
 import { App } from 'supertest/types';
 import { FRIEND_ERROR_MESSAGES } from '../src/friends/friend.constants';
 import { Friend, FriendStatus } from '../src/friends/entities/friend.entity';
+import { USER_ERROR_MESSAGES } from '../src/users/user.constants';
 import { User } from '../src/users/entities/user.entity';
 import { createAuthUserTestApp } from './test-app';
 
@@ -129,7 +130,7 @@ describe('Friend Request (e2e)', () => {
         receiverId: 999999,
       });
 
-    expectExceptionFilterErrorResponse(response, 404, 'User not found.');
+    expectExceptionFilterErrorResponse(response, 404, USER_ERROR_MESSAGES.userNotFound);
   });
 
   it('동일 방향 중복 신청 시 409', async () => {


### PR DESCRIPTION
## 연관된 이슈

- #105

## 📝 작업 내용

- [x] request/accept/reject/cancel/delete/list e2e의 실패 케이스 검증 기준 정리
- [x] `success: false`, `error.statusCode`, `error.message` 검증을 일관되게 맞춤
- [x] `FRIEND_ERROR_MESSAGES` 상수와 테스트 기대값 정렬
- [x] 기존 Friend API 상태 코드와 비즈니스 규칙 유지 검증
