### PR TITLE
게시글 카테고리 조회 API 구현 및 시드 마이그레이션 파일 작성

### DIFF
--- a/migrations/1775619600000-SeedPostCategories.ts
+++ b/migrations/1775619600000-SeedPostCategories.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeedPostCategories1775619600000 implements MigrationInterface {
+  name = 'SeedPostCategories1775619600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO "post_categories" ("name")
+      VALUES
+        ('맛집'),
+        ('후기'),
+        ('토론'),
+        ('모집'),
+        ('정보'),
+        ('잡담')
+      ON CONFLICT DO NOTHING
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "post_categories"
+      WHERE "name" IN ('맛집', '후기', '토론', '모집', '정보', '잡담')
+    `);
+  }
+}

--- a/migrations/1775636985945-AlterNameInPostCategory.ts
+++ b/migrations/1775636985945-AlterNameInPostCategory.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AlterNameInPostCategory1775636985945 implements MigrationInterface {
+    name = 'AlterNameInPostCategory1775636985945'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "post_categories" ADD CONSTRAINT "UQ_235ee0669c727771807c7f8d389" UNIQUE ("name")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "post_categories" DROP CONSTRAINT "UQ_235ee0669c727771807c7f8d389"`);
+    }
+
+}

--- a/src/post-categories/entities/post-category.entity.ts
+++ b/src/post-categories/entities/post-category.entity.ts
@@ -8,6 +8,7 @@ export class PostCategory {
 
   @Column({
     length: 50,
+    unique: true,
   })
   name: string;
 

--- a/src/post-categories/post-categories.controller.ts
+++ b/src/post-categories/post-categories.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { PostCategoryService } from './post-categories.service';
+import { PostCategory } from './entities/post-category.entity';
+
+@Controller('post-categories')
+export class PostCategoryController {
+  constructor(private readonly postCategoryService: PostCategoryService) {}
+
+  @Get()
+  async findCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryService.findCategories();
+  }
+}

--- a/src/post-categories/post-categories.controller.ts
+++ b/src/post-categories/post-categories.controller.ts
@@ -1,13 +1,17 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PostCategoryService } from './post-categories.service';
 import { PostCategory } from './entities/post-category.entity';
 
+@ApiTags('Post Category')
 @Controller('post-categories')
 export class PostCategoryController {
   constructor(private readonly postCategoryService: PostCategoryService) {}
 
   @Get()
-  async findCategories(): Promise<PostCategory[]> {
-    return await this.postCategoryService.findCategories();
+  @ApiOperation({ summary: '게시글 카테고리 조회' })
+  @ApiOkResponse({ type: PostCategory, isArray: true })
+  async findPostCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryService.findPostCategories();
   }
 }

--- a/src/post-categories/post-categories.module.ts
+++ b/src/post-categories/post-categories.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostCategory } from './entities/post-category.entity';
+import { PostCategoryController } from './post-categories.controller';
+import { PostCategoryService } from './post-categories.service';
+import { PostCategoryRepository } from './post-categories.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PostCategory])],
-  controllers: [],
-  providers: [],
+  controllers: [PostCategoryController],
+  providers: [PostCategoryService, PostCategoryRepository],
 })
 export class PostCategoryModule {}

--- a/src/post-categories/post-categories.repository.ts
+++ b/src/post-categories/post-categories.repository.ts
@@ -10,7 +10,11 @@ export class PostCategoryRepository {
     private readonly postCategoryRepository: Repository<PostCategory>,
   ) {}
 
-  async findCategories(): Promise<PostCategory[]> {
-    return await this.postCategoryRepository.find();
+  async findPostCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryRepository.find({
+      order: {
+        id: 'ASC',
+      },
+    });
   }
 }

--- a/src/post-categories/post-categories.repository.ts
+++ b/src/post-categories/post-categories.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PostCategory } from './entities/post-category.entity';
+
+@Injectable()
+export class PostCategoryRepository {
+  constructor(
+    @InjectRepository(PostCategory)
+    private readonly postCategoryRepository: Repository<PostCategory>,
+  ) {}
+
+  async findCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryRepository.find();
+  }
+}

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -6,7 +6,7 @@ import { PostCategory } from './entities/post-category.entity';
 export class PostCategoryService {
   constructor(private readonly postCategoryRepository: PostCategoryRepository) {}
 
-  async findCategories(): Promise<PostCategory[]> {
-    return await this.postCategoryRepository.findCategories();
+  async findPostCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryRepository.findPostCategories();
   }
 }

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { PostCategoryRepository } from './post-categories.repository';
+import { PostCategory } from './entities/post-category.entity';
+
+@Injectable()
+export class PostCategoryService {
+  constructor(private readonly postCategoryRepository: PostCategoryRepository) {}
+
+  async findCategories(): Promise<PostCategory[]> {
+    return await this.postCategoryRepository.findCategories();
+  }
+}

--- a/src/posts/dtos/create-post.dto.ts
+++ b/src/posts/dtos/create-post.dto.ts
@@ -1,0 +1,10 @@
+import { PickType } from '@nestjs/mapped-types';
+import { Post } from '../entities/post.entity';
+
+export class CreatePostDto extends PickType(Post, ['title', 'content', 'category']) {
+  //  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  // @ApiProperty({ example: '밥 같이 먹을 사람' })
+  // @IsString()
+  // @IsNotEmpty()
+  // @MaxLength(ROOM_CONSTANTS.TITLE_MAX_LENGTH)
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,0 +1,12 @@
+import { Controller } from '@nestjs/common';
+import { PostService } from './posts.service';
+import { Post } from '@nestjs/common';
+import { CreatePostDto } from './dtos/create-post.dto';
+
+@Controller('posts')
+export class PostController {
+  constructor(private readonly postService: PostService) {}
+
+  @Post()
+  async createPost(createPostDto: CreatePostDto): Promise<ResponsePostDetailDto> {}
+}

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -2,10 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
 import { PostLike } from './entities/post-like.entity';
+import { PostController } from './posts.controller';
+import { PostService } from './posts.service';
+import { PostRepository } from './posts.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Post, PostLike])],
-  controllers: [],
-  providers: [],
+  controllers: [PostController],
+  providers: [PostService, PostRepository],
 })
 export class PostModule {}

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Post } from './entities/post.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class PostRepository {
+  constructor(
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+  ) {}
+}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PostRepository } from './posts.repository';
+
+@Injectable()
+export class PostService {
+  constructor(private readonly postRepository: PostRepository) {}
+}


### PR DESCRIPTION

## 연관된 이슈

- #114 

## 📝 작업 내용

- [x] `PostCategoryController`에 카테고리 조회 엔드포인트 추가
- [x] `PostCategoryService` 카테고리 조회 로직 구현
- [x] `PostCategoryRepository` 카테고리 조회 로직 구현
- [x] 게시글 카테고리 시드 migration 추가
- [x] 게시글 카테고리 조회 Swagger 문서화 추가
