### PR TITLE
게시글 작성 API 구현

### DIFF
--- a/migrations/1775715869089-AddIsAnonymousInPost.ts
+++ b/migrations/1775715869089-AddIsAnonymousInPost.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsAnonymousInPost1775715869089 implements MigrationInterface {
+    name = 'AddIsAnonymousInPost1775715869089'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "posts" ADD "is_anonymous" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "posts" DROP COLUMN "is_anonymous"`);
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:room": "jest --testPathPatterns=src/rooms --coverage --collectCoverageFrom=src/rooms/**",
-    "test:post": "jest --testPathPatterns=src/posts --coverage --collectCoverageFrom=src/posts/**",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d ./src/data-source.ts",
     "migration:create": "typeorm migration:create",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d ./src/data-source.ts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:room": "jest --testPathPatterns=src/rooms --coverage --collectCoverageFrom=src/rooms/**",
+    "test:post": "jest --testPathPatterns=src/posts --coverage --collectCoverageFrom=src/posts/**",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d ./src/data-source.ts",
     "migration:create": "typeorm migration:create",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d ./src/data-source.ts",

--- a/src/post-categories/post-categories.module.ts
+++ b/src/post-categories/post-categories.module.ts
@@ -9,5 +9,6 @@ import { PostCategoryRepository } from './post-categories.repository';
   imports: [TypeOrmModule.forFeature([PostCategory])],
   controllers: [PostCategoryController],
   providers: [PostCategoryService, PostCategoryRepository],
+  exports: [PostCategoryService],
 })
 export class PostCategoryModule {}

--- a/src/post-categories/post-categories.repository.ts
+++ b/src/post-categories/post-categories.repository.ts
@@ -17,4 +17,12 @@ export class PostCategoryRepository {
       },
     });
   }
+
+  async findPostCategoryById(categoryId: number): Promise<PostCategory | null> {
+    return await this.postCategoryRepository.findOne({
+      where: {
+        id: categoryId,
+      },
+    });
+  }
 }

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostCategoryRepository } from './post-categories.repository';
 import { PostCategory } from './entities/post-category.entity';
 
@@ -8,5 +8,12 @@ export class PostCategoryService {
 
   async findPostCategories(): Promise<PostCategory[]> {
     return await this.postCategoryRepository.findPostCategories();
+  }
+
+  async findPostCategoryById(categoryId: number): Promise<PostCategory> {
+    const category = await this.postCategoryRepository.findPostCategoryById(categoryId);
+    if (!category) throw new NotFoundException('존재하지 않은 카테고리입니다.');
+
+    return category;
   }
 }

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PostCategoryRepository } from './post-categories.repository';
 import { PostCategory } from './entities/post-category.entity';
 
@@ -10,10 +10,7 @@ export class PostCategoryService {
     return await this.postCategoryRepository.findPostCategories();
   }
 
-  async findPostCategoryById(categoryId: number): Promise<PostCategory> {
-    const category = await this.postCategoryRepository.findPostCategoryById(categoryId);
-    if (!category) throw new NotFoundException('존재하지 않은 카테고리입니다.');
-
-    return category;
+  async findPostCategoryById(categoryId: number): Promise<PostCategory | null> {
+    return await this.postCategoryRepository.findPostCategoryById(categoryId);
   }
 }

--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -1,0 +1,4 @@
+export const POST_CONSTANTS = {
+  MAX_TITLE: 50,
+  MAX_CONTENTS: 1000,
+};

--- a/src/posts/dtos/create-post.dto.ts
+++ b/src/posts/dtos/create-post.dto.ts
@@ -1,10 +1,36 @@
-import { PickType } from '@nestjs/mapped-types';
-import { Post } from '../entities/post.entity';
+import { POST_CONSTANTS } from '../constants/post.constant';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsNotEmpty, IsPositive, IsString, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
 
-export class CreatePostDto extends PickType(Post, ['title', 'content', 'category']) {
-  //  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  // @ApiProperty({ example: '밥 같이 먹을 사람' })
-  // @IsString()
-  // @IsNotEmpty()
-  // @MaxLength(ROOM_CONSTANTS.TITLE_MAX_LENGTH)
+export class CreatePostDto {
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @ApiProperty({ example: '학생식당 돈까스 맛있어요' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(POST_CONSTANTS.MAX_TITLE)
+  title: string;
+
+  @ApiProperty({
+    example: `오늘 점심에 학생식당 돈까스 먹었는데 진짜 너무 맛있었어요. 소스가 특히 맛있었어요.`,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(POST_CONSTANTS.MAX_CONTENTS)
+  content: string;
+
+  @ApiProperty({
+    example: 1,
+  })
+  @IsInt()
+  @IsNotEmpty()
+  @IsPositive()
+  categoryId: number;
+
+  @ApiProperty({
+    example: false,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isAnonymous: boolean;
 }

--- a/src/posts/dtos/response-post.dto.ts
+++ b/src/posts/dtos/response-post.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostCategory } from 'src/post-categories/entities/post-category.entity';
+
+export class UserNameDto {
+  id: number;
+  nickname: string;
+}
+
+export class ResponsePostDetailDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  viewCount: number;
+
+  @ApiProperty()
+  commentCount: number;
+
+  @ApiProperty()
+  user: UserNameDto | null;
+
+  @ApiProperty()
+  category: PostCategory;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  isAnonymous: boolean;
+
+  @ApiProperty()
+  createdAt: string;
+}

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -38,6 +38,12 @@ export class Post extends BaseTableEntity {
   })
   commentCount: number;
 
+  @Column({
+    default: false,
+    name: 'is_anonymous',
+  })
+  isAnonymous: boolean;
+
   @OneToMany(() => Comment, (comment) => comment.post)
   comments: Comment[];
 

--- a/src/posts/mappers/post-mapper.ts
+++ b/src/posts/mappers/post-mapper.ts
@@ -1,0 +1,27 @@
+import { User } from 'src/users/entities/user.entity';
+import { ResponsePostDetailDto, UserNameDto } from '../dtos/response-post.dto';
+import { Post } from '../entities/post.entity';
+
+export class PostMapper {
+  static toDetailDto(post: Post): ResponsePostDetailDto {
+    return {
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      viewCount: post.viewCount,
+      commentCount: post.commentCount,
+      user: post.isAnonymous ? null : this.toUserDto(post.user),
+      category: post.category,
+      likeCount: post.likeCount,
+      isAnonymous: post.isAnonymous,
+      createdAt: post.createdAt,
+    };
+  }
+
+  static toUserDto(user: User): UserNameDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -2,7 +2,6 @@ import { Body, Controller, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
-  ApiNotFoundResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -24,7 +23,7 @@ export class PostController {
   @ApiOperation({ summary: '게시글 작성' })
   @ApiCreatedResponse({ type: ResponsePostDetailDto })
   @ApiBadRequestResponse({ description: '게시글 작성 요청 값이 올바르지 않은 경우' })
-  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
+  @ApiBadRequestResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
   @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async createPost(
     @Body() createPostDto: CreatePostDto,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,12 +1,35 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { PostService } from './posts.service';
-import { Post } from '@nestjs/common';
 import { CreatePostDto } from './dtos/create-post.dto';
+import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/auth/interfaces/jwt-payload.interface';
+import { Authenticated } from 'src/auth/decorators/authenticated.decorator';
+import { ResponsePostDetailDto } from './dtos/response-post.dto';
 
+@ApiTags('Post')
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}
 
+  @Authenticated()
   @Post()
-  async createPost(createPostDto: CreatePostDto): Promise<ResponsePostDetailDto> {}
+  @ApiOperation({ summary: '게시글 작성' })
+  @ApiCreatedResponse({ type: ResponsePostDetailDto })
+  @ApiBadRequestResponse({ description: '게시글 작성 요청 값이 올바르지 않은 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async createPost(
+    @Body() createPostDto: CreatePostDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ResponsePostDetailDto> {
+    return await this.postService.createPost(createPostDto, user.userId);
+  }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -5,9 +5,10 @@ import { PostLike } from './entities/post-like.entity';
 import { PostController } from './posts.controller';
 import { PostService } from './posts.service';
 import { PostRepository } from './posts.repository';
+import { PostCategoryModule } from 'src/post-categories/post-categories.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostLike])],
+  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule],
   controllers: [PostController],
   providers: [PostService, PostRepository],
 })

--- a/src/posts/posts.repository.spec.ts
+++ b/src/posts/posts.repository.spec.ts
@@ -1,0 +1,70 @@
+import { Repository } from 'typeorm';
+import { PostRepository } from './posts.repository';
+import { Post } from './entities/post.entity';
+import { CreatePostDto } from './dtos/create-post.dto';
+
+describe('PostRepository', () => {
+  let postRepository: PostRepository;
+  let postOrmRepository: Pick<Repository<Post>, 'save' | 'findOne'>;
+
+  beforeEach(() => {
+    postOrmRepository = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    postRepository = new PostRepository(postOrmRepository as Repository<Post>);
+  });
+
+  describe('createPost', () => {
+    it('작성 DTO와 userId로 save를 호출', async () => {
+      const createPostDto: CreatePostDto = {
+        title: '학생식당 돈까스 맛있어요',
+        content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+        categoryId: 1,
+        isAnonymous: false,
+      };
+      const savedPost = {
+        id: 1,
+        ...createPostDto,
+      };
+
+      (postOrmRepository.save as jest.Mock).mockResolvedValue(savedPost);
+
+      const result = await postRepository.createPost(createPostDto, 7);
+
+      expect(result).toEqual(savedPost);
+      expect(postOrmRepository.save).toHaveBeenCalledWith({
+        title: createPostDto.title,
+        content: createPostDto.content,
+        isAnonymous: createPostDto.isAnonymous,
+        category: { id: createPostDto.categoryId },
+        user: { id: 7 },
+      });
+    });
+  });
+
+  describe('findPostById', () => {
+    it('postId와 relations 조건으로 findOne을 호출', async () => {
+      const post = {
+        id: 1,
+        title: '게시글',
+      };
+
+      (postOrmRepository.findOne as jest.Mock).mockResolvedValue(post);
+
+      const result = await postRepository.findPostById(1);
+
+      expect(result).toEqual(post);
+      expect(postOrmRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+        },
+        relations: {
+          category: true,
+          user: true,
+        },
+      });
+    });
+  });
+});

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
 import { Repository } from 'typeorm';
+import { CreatePostDto } from './dtos/create-post.dto';
 
 @Injectable()
 export class PostRepository {
@@ -9,4 +10,26 @@ export class PostRepository {
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
   ) {}
+
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<Post> {
+    return await this.postRepository.save({
+      title: createPostDto.title,
+      content: createPostDto.content,
+      isAnonymous: createPostDto.isAnonymous,
+      category: { id: createPostDto.categoryId },
+      user: { id: userId },
+    });
+  }
+
+  async findPostById(postId: number): Promise<Post | null> {
+    return await this.postRepository.findOne({
+      where: {
+        id: postId,
+      },
+      relations: {
+        category: true,
+        user: true,
+      },
+    });
+  }
 }

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PostService } from './posts.service';
+import { PostRepository } from './posts.repository';
+import { PostCategoryService } from 'src/post-categories/post-categories.service';
+import { CreatePostDto } from './dtos/create-post.dto';
+import { PostMapper } from './mappers/post-mapper';
+
+const createPostDto: CreatePostDto = {
+  title: '학생식당 돈까스 맛있어요',
+  content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+  categoryId: 1,
+  isAnonymous: false,
+};
+
+const mockCategory = {
+  id: 1,
+  name: '자유',
+};
+
+const mockCreatedPost = {
+  id: 3,
+};
+
+const mockPostEntity = {
+  id: 3,
+  title: createPostDto.title,
+  content: createPostDto.content,
+  viewCount: 0,
+  commentCount: 0,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-09T00:00:00.000Z',
+  category: mockCategory,
+  user: {
+    id: 7,
+    nickname: 'writer',
+  },
+};
+
+const mockPostDetailDto = {
+  id: 3,
+  title: createPostDto.title,
+  content: createPostDto.content,
+  viewCount: 0,
+  commentCount: 0,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-09T00:00:00.000Z',
+  category: mockCategory,
+  user: {
+    id: 7,
+    nickname: 'writer',
+  },
+};
+
+const mockPostRepository = {
+  createPost: jest.fn(),
+  findPostById: jest.fn(),
+};
+
+const mockPostCategoryService = {
+  findPostCategoryById: jest.fn(),
+};
+
+describe('PostService', () => {
+  let postService: PostService;
+  let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostService,
+        {
+          provide: PostRepository,
+          useValue: mockPostRepository,
+        },
+        {
+          provide: PostCategoryService,
+          useValue: mockPostCategoryService,
+        },
+      ],
+    }).compile();
+
+    postService = module.get<PostService>(PostService);
+  });
+
+  describe('createPost', () => {
+    it('카테고리를 검증하고 생성된 게시글 상세 정보를 반환', async () => {
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
+
+      const result = await postService.createPost(createPostDto, 7);
+
+      expect(result).toEqual(mockPostDetailDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
+        createPostDto.categoryId,
+      );
+      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+    });
+
+    it('생성 후 게시글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(postService.createPost(createPostDto, 7)).rejects.toThrow(NotFoundException);
+
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
+        createPostDto.categoryId,
+      );
+      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+    });
+  });
+});

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,7 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
+import { CreatePostDto } from './dtos/create-post.dto';
+import { PostCategoryService } from 'src/post-categories/post-categories.service';
+import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import { PostMapper } from './mappers/post-mapper';
 
 @Injectable()
 export class PostService {
-  constructor(private readonly postRepository: PostRepository) {}
+  constructor(
+    private readonly postRepository: PostRepository,
+    private readonly postCategoryService: PostCategoryService,
+  ) {}
+
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
+    const categoryId = createPostDto.categoryId;
+
+    await this.postCategoryService.findPostCategoryById(categoryId);
+
+    const createdPost = await this.postRepository.createPost(createPostDto, userId);
+
+    const post = await this.postRepository.findPostById(createdPost.id);
+
+    if (!post) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+
+    return PostMapper.toDetailDto(post);
+  }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
@@ -15,7 +15,8 @@ export class PostService {
   async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
     const categoryId = createPostDto.categoryId;
 
-    await this.postCategoryService.findPostCategoryById(categoryId);
+    const existingCategory = await this.postCategoryService.findPostCategoryById(categoryId);
+    if (!existingCategory) throw new BadRequestException('존재하지 않는 카테고리입니다.');
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 

--- a/test/posts-create.e2e-spec.ts
+++ b/test/posts-create.e2e-spec.ts
@@ -1,0 +1,192 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { Post } from '../src/posts/entities/post.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Posts Create (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  function expectExceptionFilterErrorResponse(
+    response: Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
+
+  it('POST /posts 게시글 작성 성공', async () => {
+    const signupResponse = await signupUser('writer@example.com', 'writer');
+    const category = await createCategory('자유');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '학생식당 돈까스 맛있어요',
+        content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+        categoryId: category.id,
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toEqual(expect.any(Number));
+    expect(response.body.title).toBe('학생식당 돈까스 맛있어요');
+    expect(response.body.content).toBe('오늘 점심에 먹었는데 소스가 정말 맛있었어요.');
+    expect(response.body.viewCount).toBe(0);
+    expect(response.body.commentCount).toBe(0);
+    expect(response.body.likeCount).toBe(0);
+    expect(response.body.isAnonymous).toBe(false);
+    expect(response.body.user).toEqual({
+      id: signupResponse.body.user.id,
+      nickname: 'writer',
+    });
+    expect(response.body.category).toEqual({
+      id: category.id,
+      name: '자유',
+    });
+    expect(response.body.createdAt).toEqual(expect.any(String));
+
+    const createdPost = await dataSource.getRepository(Post).findOne({
+      where: { id: response.body.id },
+      relations: {
+        user: true,
+        category: true,
+      },
+    });
+
+    expect(createdPost).toBeDefined();
+    expect(createdPost?.title).toBe('학생식당 돈까스 맛있어요');
+    expect(createdPost?.content).toBe('오늘 점심에 먹었는데 소스가 정말 맛있었어요.');
+    expect(createdPost?.user.id).toBe(signupResponse.body.user.id);
+    expect(createdPost?.category.id).toBe(category.id);
+  });
+
+  it('POST /posts 익명 게시글 작성 성공 시 user 는 null 이다', async () => {
+    const signupResponse = await signupUser('anonymous@example.com', 'anonymous-writer');
+    const category = await createCategory('정보');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '익명 후기',
+        content: '오늘 메뉴 꽤 괜찮았어요.',
+        categoryId: category.id,
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.isAnonymous).toBe(true);
+    expect(response.body.user).toBeNull();
+    expect(response.body.category).toEqual({
+      id: category.id,
+      name: '정보',
+    });
+  });
+
+  it('POST /posts 존재하지 않는 카테고리면 실패', async () => {
+    const signupResponse = await signupUser('missing-category@example.com', 'missing-category');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '없는 카테고리 글',
+        content: '이 요청은 실패해야 해요.',
+        categoryId: 999,
+        isAnonymous: false,
+      });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+  });
+
+  it('POST /posts 잘못된 요청값이면 실패', async () => {
+    const signupResponse = await signupUser('invalid-post@example.com', 'invalid-post');
+    const category = await createCategory('질문');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '   ',
+        content: '',
+        categoryId: 0,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining([
+        'title should not be empty',
+        'content should not be empty',
+        'categoryId must be a positive number',
+        'isAnonymous should not be empty',
+        'isAnonymous must be a boolean value',
+      ]),
+    );
+
+    const posts = await dataSource.getRepository(Post).find();
+    expect(posts).toHaveLength(0);
+    expect(category.id).toBeGreaterThan(0);
+  });
+
+  it('POST /posts 인증 없이 요청하면 실패', async () => {
+    const category = await createCategory('자유');
+
+    const response = await request(httpApp()).post('/posts').send({
+      title: '로그인 없이 작성',
+      content: '이 요청은 인증이 필요해요.',
+      categoryId: category.id,
+      isAnonymous: false,
+    });
+
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+  });
+});

--- a/test/posts-create.e2e-spec.ts
+++ b/test/posts-create.e2e-spec.ts
@@ -47,19 +47,6 @@ describe('Posts Create (e2e)', () => {
     return await dataSource.getRepository(PostCategory).save({ name });
   }
 
-  function expectExceptionFilterErrorResponse(
-    response: Response,
-    statusCode: number,
-    message: string | string[],
-  ): void {
-    expect(response.status).toBe(statusCode);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toEqual({
-      statusCode,
-      message,
-    });
-  }
-
   it('POST /posts 게시글 작성 성공', async () => {
     const signupResponse = await signupUser('writer@example.com', 'writer');
     const category = await createCategory('자유');
@@ -143,7 +130,12 @@ describe('Posts Create (e2e)', () => {
         isAnonymous: false,
       });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 400,
+      message: '존재하지 않는 카테고리입니다.',
+    });
   });
 
   it('POST /posts 잘못된 요청값이면 실패', async () => {
@@ -187,6 +179,11 @@ describe('Posts Create (e2e)', () => {
       isAnonymous: false,
     });
 
-    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
   });
 });

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -21,6 +21,7 @@ import { FriendModule } from '../src/friends/friends.module';
 import { MealMenuReaction } from '../src/meal-menus/entities/meal-menu-reaction.entity';
 import { MealMenu } from '../src/meal-menus/entities/meal-menu.entity';
 import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { PostModule } from '../src/posts/posts.module';
 import { PostLike } from '../src/posts/entities/post-like.entity';
 import { Post } from '../src/posts/entities/post.entity';
 import { RoomMember } from '../src/rooms/entities/room-member.entity';
@@ -104,6 +105,7 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
       }),
       UserModule,
       AuthModule,
+      PostModule,
       RoomModule,
       FriendModule,
     ],


### PR DESCRIPTION
## 연관된 이슈

- #113 

## 📝 작업 내용

- [x] 게시글 익명 여부 컬럼 추가
- [x] `POST /posts` 게시글 작성 API 구현
- [x] `PostController`에 게시글 작성 엔트포인트 추가
- [x] 로그인 사용자 기반 게시글 작성 로직 연결
- [x] 데이터 검증 DTO 작성
- [x] 응답 Mapper 작성
- [x] 게시글 작성 Swagger 문서화 추가
- [x] `PostCategory` 게시글 카테고리 조회 로직 추가
- [x] 게시글 작성 단위 테스트 추가
- [x] 게시글 작성 e2e 테스트 추가
