### PR TITLE
게시글 목록 및 상세 조회 API 구현

### DIFF
--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -2,3 +2,8 @@ export const POST_CONSTANTS = {
   MAX_TITLE: 50,
   MAX_CONTENTS: 1000,
 };
+
+export const PAGINATION_CONSTANTS = {
+  MAX_LIMIT: 200,
+  DEFAULT_LIMIT: 20,
+};

--- a/src/posts/dtos/find-posts-query.dto.ts
+++ b/src/posts/dtos/find-posts-query.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, Max, Min } from 'class-validator';
+import { PAGINATION_CONSTANTS } from '../constants/post.constant';
+
+export class FindPostsQueryDto {
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  cursor?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: PAGINATION_CONSTANTS.MAX_LIMIT })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
+  limit?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  categoryId?: number;
+}

--- a/src/posts/dtos/response-post.dto.ts
+++ b/src/posts/dtos/response-post.dto.ts
@@ -1,8 +1,12 @@
+import { PickType } from '@nestjs/mapped-types';
 import { ApiProperty } from '@nestjs/swagger';
 import { PostCategory } from 'src/post-categories/entities/post-category.entity';
 
-export class UserNameDto {
+export class PostAuthorDto {
+  @ApiProperty()
   id: number;
+
+  @ApiProperty()
   nickname: string;
 }
 
@@ -22,10 +26,10 @@ export class ResponsePostDetailDto {
   @ApiProperty()
   commentCount: number;
 
-  @ApiProperty()
-  user: UserNameDto | null;
+  @ApiProperty({ type: () => PostAuthorDto, nullable: true })
+  user: PostAuthorDto | null;
 
-  @ApiProperty()
+  @ApiProperty({ type: () => PostCategory })
   category: PostCategory;
 
   @ApiProperty()
@@ -36,4 +40,25 @@ export class ResponsePostDetailDto {
 
   @ApiProperty()
   createdAt: string;
+}
+
+export class ResponsePostListItemDto extends PickType(ResponsePostDetailDto, [
+  'id',
+  'title',
+  'createdAt',
+  'likeCount',
+  'viewCount',
+  'commentCount',
+  'user',
+]) {}
+
+export class ResponsePostListDto {
+  @ApiProperty({ type: () => [ResponsePostListItemDto] })
+  items: ResponsePostListItemDto[];
+
+  @ApiProperty({ nullable: true })
+  nextCursor: number | null;
+
+  @ApiProperty()
+  hasNext: boolean;
 }

--- a/src/posts/mappers/post-mapper.ts
+++ b/src/posts/mappers/post-mapper.ts
@@ -1,24 +1,47 @@
 import { User } from 'src/users/entities/user.entity';
-import { ResponsePostDetailDto, UserNameDto } from '../dtos/response-post.dto';
+import {
+  PostAuthorDto,
+  ResponsePostDetailDto,
+  ResponsePostListDto,
+  ResponsePostListItemDto,
+} from '../dtos/response-post.dto';
 import { Post } from '../entities/post.entity';
 
 export class PostMapper {
-  static toDetailDto(post: Post): ResponsePostDetailDto {
+  static toListDto(
+    posts: Post[],
+    nextCursor: number | null,
+    hasNext: boolean,
+  ): ResponsePostListDto {
     return {
-      id: post.id,
-      title: post.title,
-      content: post.content,
-      viewCount: post.viewCount,
-      commentCount: post.commentCount,
-      user: post.isAnonymous ? null : this.toUserDto(post.user),
-      category: post.category,
-      likeCount: post.likeCount,
-      isAnonymous: post.isAnonymous,
-      createdAt: post.createdAt,
+      items: posts.map((post) => this.toListItemDto(post)),
+      nextCursor,
+      hasNext,
     };
   }
 
-  static toUserDto(user: User): UserNameDto {
+  static toListItemDto(post: Post): ResponsePostListItemDto {
+    return {
+      id: post.id,
+      title: post.title,
+      viewCount: post.viewCount,
+      likeCount: post.likeCount,
+      commentCount: post.commentCount,
+      createdAt: post.createdAt,
+      user: post.isAnonymous ? null : this.toPostAuthorDto(post.user),
+    };
+  }
+
+  static toDetailDto(post: Post): ResponsePostDetailDto {
+    return {
+      ...this.toListItemDto(post),
+      content: post.content,
+      category: post.category,
+      isAnonymous: post.isAnonymous,
+    };
+  }
+
+  static toPostAuthorDto(user: User): PostAuthorDto {
     return {
       id: user.id,
       nickname: user.nickname,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,9 +1,13 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
+  ApiParam,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -12,9 +16,15 @@ import { CreatePostDto } from './dtos/create-post.dto';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from 'src/auth/interfaces/jwt-payload.interface';
 import { Authenticated } from 'src/auth/decorators/authenticated.decorator';
-import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import {
+  ResponsePostDetailDto,
+  ResponsePostListDto,
+  ResponsePostListItemDto,
+} from './dtos/response-post.dto';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 @ApiTags('Post')
+@ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}
@@ -31,5 +41,26 @@ export class PostController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostDetailDto> {
     return await this.postService.createPost(createPostDto, user.userId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: '게시글 목록 조회' })
+  @ApiQuery({ name: 'cursor', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'categoryId', required: false, type: Number })
+  @ApiOkResponse({ type: ResponsePostListDto })
+  @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })
+  async findPosts(@Query() query: FindPostsQueryDto): Promise<ResponsePostListDto> {
+    return await this.postService.findPosts(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '게시글 상세 조회' })
+  @ApiParam({ name: 'id', description: '조회할 게시글 ID', type: Number })
+  @ApiOkResponse({ type: ResponsePostDetailDto })
+  @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
+  async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {
+    return await this.postService.findPostById(postId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -53,7 +53,6 @@ export class PostController {
 
   @Get(':id')
   @ApiOperation({ summary: '게시글 상세 조회' })
-  @ApiParam({ name: 'id', description: '조회할 게시글 ID', type: Number })
   @ApiOkResponse({ type: ResponsePostDetailDto })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
   async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -7,7 +7,6 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
-  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -45,9 +44,6 @@ export class PostController {
 
   @Get()
   @ApiOperation({ summary: '게시글 목록 조회' })
-  @ApiQuery({ name: 'cursor', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'categoryId', required: false, type: Number })
   @ApiOkResponse({ type: ResponsePostListDto })
   @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
   @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,7 +6,6 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -21,6 +20,7 @@ import {
   ResponsePostListItemDto,
 } from './dtos/response-post.dto';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { PostMapper } from './mappers/post-mapper';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -39,7 +39,9 @@ export class PostController {
     @Body() createPostDto: CreatePostDto,
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostDetailDto> {
-    return await this.postService.createPost(createPostDto, user.userId);
+    const createdPost = await this.postService.createPost(createPostDto, user.userId);
+
+    return PostMapper.toDetailDto(createdPost);
   }
 
   @Get()
@@ -48,7 +50,9 @@ export class PostController {
   @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
   @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })
   async findPosts(@Query() query: FindPostsQueryDto): Promise<ResponsePostListDto> {
-    return await this.postService.findPosts(query);
+    const { items, nextCursor, hasNext } = await this.postService.findPosts(query);
+
+    return PostMapper.toListDto(items, nextCursor, hasNext);
   }
 
   @Get(':id')
@@ -56,6 +60,8 @@ export class PostController {
   @ApiOkResponse({ type: ResponsePostDetailDto })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
   async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {
-    return await this.postService.findPostById(postId);
+    const post = await this.postService.findPostById(postId);
+
+    return PostMapper.toDetailDto(post);
   }
 }

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, LessThan, Repository } from 'typeorm';
 import { CreatePostDto } from './dtos/create-post.dto';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 @Injectable()
 export class PostRepository {
@@ -30,6 +31,25 @@ export class PostRepository {
         category: true,
         user: true,
       },
+    });
+  }
+
+  async findPosts(query: FindPostsQueryDto, limit: number): Promise<Post[]> {
+    const where: FindOptionsWhere<Post> = {};
+
+    if (query.categoryId !== undefined) where.category = { id: query.categoryId };
+    if (query.cursor !== undefined) where.id = LessThan(query.cursor);
+
+    return await this.postRepository.find({
+      where,
+      relations: {
+        user: true,
+        category: true,
+      },
+      order: {
+        id: 'DESC',
+      },
+      take: limit + 1,
     });
   }
 }

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -4,7 +4,6 @@ import { PostService } from './posts.service';
 import { PostRepository } from './posts.repository';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
 import { CreatePostDto } from './dtos/create-post.dto';
-import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 const createPostDto: CreatePostDto = {
@@ -39,41 +38,6 @@ const mockPostEntity = {
   },
 };
 
-const mockPostDetailDto = {
-  id: 3,
-  title: createPostDto.title,
-  content: createPostDto.content,
-  viewCount: 0,
-  commentCount: 0,
-  likeCount: 0,
-  isAnonymous: false,
-  createdAt: '2026-04-09T00:00:00.000Z',
-  category: mockCategory,
-  user: {
-    id: 7,
-    nickname: 'writer',
-  },
-};
-
-const mockPostListDto = {
-  items: [
-    {
-      id: 3,
-      title: createPostDto.title,
-      viewCount: 0,
-      likeCount: 0,
-      commentCount: 0,
-      createdAt: '2026-04-09T00:00:00.000Z',
-      user: {
-        id: 7,
-        nickname: 'writer',
-      },
-    },
-  ],
-  nextCursor: null,
-  hasNext: false,
-};
-
 const mockPostRepository = {
   createPost: jest.fn(),
   findPostById: jest.fn(),
@@ -86,14 +50,10 @@ const mockPostCategoryService = {
 
 describe('PostService', () => {
   let postService: PostService;
-  let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
-  let toListDtoSpy: jest.SpiedFunction<typeof PostMapper.toListDto>;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
-    toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
-    toListDtoSpy = jest.spyOn(PostMapper, 'toListDto');
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -117,17 +77,15 @@ describe('PostService', () => {
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
       mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
       mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
-      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
 
       const result = await postService.createPost(createPostDto, 7);
 
-      expect(result).toEqual(mockPostDetailDto);
+      expect(result).toEqual(mockPostEntity);
       expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
         createPostDto.categoryId,
       );
       expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
       expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
-      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
     });
 
     it('생성 후 게시글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
@@ -154,14 +112,16 @@ describe('PostService', () => {
 
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
       mockPostRepository.findPosts.mockResolvedValue([mockPostEntity]);
-      toListDtoSpy.mockReturnValue(mockPostListDto);
 
       const result = await postService.findPosts(query);
 
-      expect(result).toEqual(mockPostListDto);
+      expect(result).toEqual({
+        items: [mockPostEntity],
+        nextCursor: null,
+        hasNext: false,
+      });
       expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(query.categoryId);
       expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 20);
-      expect(toListDtoSpy).toHaveBeenCalledWith([mockPostEntity], null, false);
     });
 
     it('다음 페이지가 있으면 limit 만큼만 잘라 nextCursor와 함께 반환', async () => {
@@ -173,33 +133,27 @@ describe('PostService', () => {
         id: 1,
       };
       const foundPosts = [mockPostEntity, { ...mockPostEntity, id: 2 }, thirdPost];
-      const paginatedResult = {
-        ...mockPostListDto,
-        nextCursor: 2,
-        hasNext: true,
-      };
-
       mockPostRepository.findPosts.mockResolvedValue(foundPosts);
-      toListDtoSpy.mockReturnValue(paginatedResult);
 
       const result = await postService.findPosts(query);
 
-      expect(result).toEqual(paginatedResult);
+      expect(result).toEqual({
+        items: foundPosts.slice(0, 2),
+        nextCursor: 2,
+        hasNext: true,
+      });
       expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
       expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 2);
-      expect(toListDtoSpy).toHaveBeenCalledWith(foundPosts.slice(0, 2), 2, true);
     });
   });
 
   describe('findPostById', () => {
     it('게시글 상세 정보를 반환', async () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
-      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
 
       const result = await postService.findPostById(3);
 
-      expect(result).toEqual(mockPostDetailDto);
-      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+      expect(result).toEqual(mockPostEntity);
     });
 
     it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -5,6 +5,7 @@ import { PostRepository } from './posts.repository';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostMapper } from './mappers/post-mapper';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 const createPostDto: CreatePostDto = {
   title: '학생식당 돈까스 맛있어요',
@@ -54,9 +55,29 @@ const mockPostDetailDto = {
   },
 };
 
+const mockPostListDto = {
+  items: [
+    {
+      id: 3,
+      title: createPostDto.title,
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: '2026-04-09T00:00:00.000Z',
+      user: {
+        id: 7,
+        nickname: 'writer',
+      },
+    },
+  ],
+  nextCursor: null,
+  hasNext: false,
+};
+
 const mockPostRepository = {
   createPost: jest.fn(),
   findPostById: jest.fn(),
+  findPosts: jest.fn(),
 };
 
 const mockPostCategoryService = {
@@ -66,11 +87,13 @@ const mockPostCategoryService = {
 describe('PostService', () => {
   let postService: PostService;
   let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
+  let toListDtoSpy: jest.SpiedFunction<typeof PostMapper.toListDto>;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
     toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
+    toListDtoSpy = jest.spyOn(PostMapper, 'toListDto');
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -119,6 +142,73 @@ describe('PostService', () => {
       );
       expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
       expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+    });
+  });
+
+  describe('findPosts', () => {
+    it('카테고리 조건이 있으면 검증 후 게시글 목록 반환', async () => {
+      const query: FindPostsQueryDto = {
+        categoryId: 1,
+        limit: 20,
+      };
+
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.findPosts.mockResolvedValue([mockPostEntity]);
+      toListDtoSpy.mockReturnValue(mockPostListDto);
+
+      const result = await postService.findPosts(query);
+
+      expect(result).toEqual(mockPostListDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(query.categoryId);
+      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 20);
+      expect(toListDtoSpy).toHaveBeenCalledWith([mockPostEntity], null, false);
+    });
+
+    it('다음 페이지가 있으면 limit 만큼만 잘라 nextCursor와 함께 반환', async () => {
+      const query: FindPostsQueryDto = {
+        limit: 2,
+      };
+      const thirdPost = {
+        ...mockPostEntity,
+        id: 1,
+      };
+      const foundPosts = [mockPostEntity, { ...mockPostEntity, id: 2 }, thirdPost];
+      const paginatedResult = {
+        ...mockPostListDto,
+        nextCursor: 2,
+        hasNext: true,
+      };
+
+      mockPostRepository.findPosts.mockResolvedValue(foundPosts);
+      toListDtoSpy.mockReturnValue(paginatedResult);
+
+      const result = await postService.findPosts(query);
+
+      expect(result).toEqual(paginatedResult);
+      expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
+      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 2);
+      expect(toListDtoSpy).toHaveBeenCalledWith(foundPosts.slice(0, 2), 2, true);
+    });
+  });
+
+  describe('findPostById', () => {
+    it('게시글 상세 정보를 반환', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
+
+      const result = await postService.findPostById(3);
+
+      expect(result).toEqual(mockPostDetailDto);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
+      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(postService.findPostById(999)).rejects.toThrow(NotFoundException);
+
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(999);
     });
   });
 });

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -199,7 +199,6 @@ describe('PostService', () => {
       const result = await postService.findPostById(3);
 
       expect(result).toEqual(mockPostDetailDto);
-      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
       expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
     });
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -2,10 +2,10 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
-import { ResponsePostDetailDto, ResponsePostListDto } from './dtos/response-post.dto';
-import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 import { PAGINATION_CONSTANTS } from './constants/post.constant';
+import { Post } from './entities/post.entity';
+import { FindPostsResult } from './types/post.type';
 
 @Injectable()
 export class PostService {
@@ -14,7 +14,7 @@ export class PostService {
     private readonly postCategoryService: PostCategoryService,
   ) {}
 
-  async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<Post> {
     const categoryId = createPostDto.categoryId;
 
     await this.postCategoryService.findPostCategoryById(categoryId);
@@ -25,10 +25,10 @@ export class PostService {
 
     if (!newPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
 
-    return PostMapper.toDetailDto(newPostDetail);
+    return newPostDetail;
   }
 
-  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<ResponsePostListDto> {
+  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<FindPostsResult> {
     if (findPostsQuery.categoryId !== undefined)
       await this.postCategoryService.findPostCategoryById(findPostsQuery.categoryId);
 
@@ -38,14 +38,18 @@ export class PostService {
     const paginatedPosts = hasNext ? posts.slice(0, limit) : posts;
     const nextCursor = hasNext ? paginatedPosts[paginatedPosts.length - 1].id : null;
 
-    return PostMapper.toListDto(paginatedPosts, nextCursor, hasNext);
+    return {
+      items: paginatedPosts,
+      nextCursor,
+      hasNext,
+    };
   }
 
-  async findPostById(postId: number): Promise<ResponsePostDetailDto> {
+  async findPostById(postId: number): Promise<Post> {
     const post = await this.postRepository.findPostById(postId);
 
     if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
-    return PostMapper.toDetailDto(post);
+    return post;
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -2,8 +2,10 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
-import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import { ResponsePostDetailDto, ResponsePostListDto } from './dtos/response-post.dto';
 import { PostMapper } from './mappers/post-mapper';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { PAGINATION_CONSTANTS } from './constants/post.constant';
 
 @Injectable()
 export class PostService {
@@ -19,9 +21,30 @@ export class PostService {
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 
-    const post = await this.postRepository.findPostById(createdPost.id);
+    const newPostDetail = await this.postRepository.findPostById(createdPost.id);
 
-    if (!post) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+    if (!newPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+
+    return PostMapper.toDetailDto(newPostDetail);
+  }
+
+  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<ResponsePostListDto> {
+    if (findPostsQuery.categoryId !== undefined)
+      await this.postCategoryService.findPostCategoryById(findPostsQuery.categoryId);
+
+    const limit = findPostsQuery.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
+    const posts = await this.postRepository.findPosts(findPostsQuery, limit);
+    const hasNext = posts.length > limit;
+    const paginatedPosts = hasNext ? posts.slice(0, limit) : posts;
+    const nextCursor = hasNext ? paginatedPosts[paginatedPosts.length - 1].id : null;
+
+    return PostMapper.toListDto(paginatedPosts, nextCursor, hasNext);
+  }
+
+  async findPostById(postId: number): Promise<ResponsePostDetailDto> {
+    const post = await this.postRepository.findPostById(postId);
+
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
     return PostMapper.toDetailDto(post);
   }

--- a/src/posts/types/post.type.ts
+++ b/src/posts/types/post.type.ts
@@ -1,0 +1,7 @@
+import { Post } from '../entities/post.entity';
+
+export type FindPostsResult = {
+  items: Post[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};

--- a/test/posts-read.e2e-spec.ts
+++ b/test/posts-read.e2e-spec.ts
@@ -63,19 +63,6 @@ describe('Posts Read (e2e)', () => {
     });
   }
 
-  function expectExceptionFilterErrorResponse(
-    response: Response,
-    statusCode: number,
-    message: string | string[],
-  ): void {
-    expect(response.status).toBe(statusCode);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toEqual({
-      statusCode,
-      message,
-    });
-  }
-
   it('GET /posts 전체 게시글 목록 조회 성공', async () => {
     const writerSignup = await signupUser('posts-list@example.com', 'list-writer');
     const writer = await dataSource.getRepository(User).findOneByOrFail({
@@ -225,7 +212,12 @@ describe('Posts Read (e2e)', () => {
       categoryId: 999,
     });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않은 카테고리입니다.',
+    });
   });
 
   it('GET /posts/:id 게시글 상세 조회 성공', async () => {
@@ -288,7 +280,12 @@ describe('Posts Read (e2e)', () => {
   it('GET /posts/:id 존재하지 않는 게시글이면 실패', async () => {
     const response = await request(httpApp()).get('/posts/999');
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
   });
 
   it('GET /posts/:id 잘못된 게시글 ID 면 실패', async () => {

--- a/test/posts-read.e2e-spec.ts
+++ b/test/posts-read.e2e-spec.ts
@@ -1,0 +1,301 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { Post } from '../src/posts/entities/post.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Posts Read (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPostFixture(params: {
+    title: string;
+    content: string;
+    user: User;
+    category: PostCategory;
+    isAnonymous?: boolean;
+  }): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: params.title,
+      content: params.content,
+      user: params.user,
+      category: params.category,
+      isAnonymous: params.isAnonymous ?? false,
+    });
+  }
+
+  function expectExceptionFilterErrorResponse(
+    response: Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
+
+  it('GET /posts 전체 게시글 목록 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-list@example.com', 'list-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+
+    const olderPost = await createPostFixture({
+      title: '첫 번째 글',
+      content: '첫 번째 내용',
+      user: writer,
+      category: freeCategory,
+    });
+    const latestPost = await createPostFixture({
+      title: '두 번째 글',
+      content: '두 번째 내용',
+      user: writer,
+      category: infoCategory,
+    });
+
+    const response = await request(httpApp()).get('/posts');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0]).toEqual({
+      id: latestPost.id,
+      title: '두 번째 글',
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: expect.any(String),
+      user: {
+        id: writer.id,
+        nickname: writer.nickname,
+      },
+    });
+    expect(response.body.items[1].id).toBe(olderPost.id);
+    expect(response.body.nextCursor).toBeNull();
+    expect(response.body.hasNext).toBe(false);
+    expect(response.body.items[0].content).toBeUndefined();
+  });
+
+  it('GET /posts categoryId 로 필터링 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-category@example.com', 'category-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+
+    await createPostFixture({
+      title: '자유 글',
+      content: '자유 내용',
+      user: writer,
+      category: freeCategory,
+    });
+    await createPostFixture({
+      title: '정보 글',
+      content: '정보 내용',
+      user: writer,
+      category: infoCategory,
+    });
+
+    const response = await request(httpApp()).get('/posts').query({
+      categoryId: infoCategory.id,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].title).toBe('정보 글');
+  });
+
+  it('GET /posts 커서 기반 페이징 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-cursor@example.com', 'cursor-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+
+    const firstPost = await createPostFixture({
+      title: '첫 글',
+      content: '첫 글 내용',
+      user: writer,
+      category,
+    });
+    const secondPost = await createPostFixture({
+      title: '둘째 글',
+      content: '둘째 글 내용',
+      user: writer,
+      category,
+    });
+    const thirdPost = await createPostFixture({
+      title: '셋째 글',
+      content: '셋째 글 내용',
+      user: writer,
+      category,
+    });
+
+    const firstPageResponse = await request(httpApp()).get('/posts').query({
+      limit: 2,
+    });
+
+    expect(firstPageResponse.status).toBe(200);
+    expect(firstPageResponse.body.items).toHaveLength(2);
+    expect(firstPageResponse.body.items[0].id).toBe(thirdPost.id);
+    expect(firstPageResponse.body.items[1].id).toBe(secondPost.id);
+    expect(firstPageResponse.body.nextCursor).toBe(secondPost.id);
+    expect(firstPageResponse.body.hasNext).toBe(true);
+
+    const nextPageResponse = await request(httpApp()).get('/posts').query({
+      cursor: firstPageResponse.body.nextCursor,
+      limit: 2,
+    });
+
+    expect(nextPageResponse.status).toBe(200);
+    expect(nextPageResponse.body.items).toHaveLength(1);
+    expect(nextPageResponse.body.items[0].id).toBe(firstPost.id);
+    expect(nextPageResponse.body.nextCursor).toBeNull();
+    expect(nextPageResponse.body.hasNext).toBe(false);
+  });
+
+  it('GET /posts 익명 게시글은 작성자 정보를 숨긴다', async () => {
+    const writerSignup = await signupUser('posts-anonymous@example.com', 'anonymous-reader');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+
+    await createPostFixture({
+      title: '익명 글',
+      content: '익명 내용',
+      user: writer,
+      category,
+      isAnonymous: true,
+    });
+
+    const response = await request(httpApp()).get('/posts');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].user).toBeNull();
+  });
+
+  it('GET /posts 존재하지 않는 카테고리면 실패', async () => {
+    const response = await request(httpApp()).get('/posts').query({
+      categoryId: 999,
+    });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+  });
+
+  it('GET /posts/:id 게시글 상세 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-detail@example.com', 'detail-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '상세 글',
+      content: '상세 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      id: post.id,
+      title: '상세 글',
+      content: '상세 내용',
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: expect.any(String),
+      user: {
+        id: writer.id,
+        nickname: writer.nickname,
+      },
+      category: {
+        id: category.id,
+        name: category.name,
+      },
+      isAnonymous: false,
+    });
+  });
+
+  it('GET /posts/:id 익명 게시글 상세 조회 시 작성자 정보를 숨긴다', async () => {
+    const writerSignup = await signupUser('posts-detail-anon@example.com', 'detail-anon');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('익명');
+    const post = await createPostFixture({
+      title: '익명 상세 글',
+      content: '익명 상세 내용',
+      user: writer,
+      category,
+      isAnonymous: true,
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toBeNull();
+    expect(response.body.isAnonymous).toBe(true);
+  });
+
+  it('GET /posts/:id 존재하지 않는 게시글이면 실패', async () => {
+    const response = await request(httpApp()).get('/posts/999');
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+  });
+
+  it('GET /posts/:id 잘못된 게시글 ID 면 실패', async () => {
+    const response = await request(httpApp()).get('/posts/abc');
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## 연관된 이슈

- #116 

## 📝 작업 내용

- [x] `GET /posts` 게시글 목록 조회 API 구현
- [x] `GET /posts/:id` 게시글 상세 조회 API 구현
- [x] `FindPostsQueryDto` 기반 커서/limit/카테고리 필터 조회 처리
- [x] 존재하지 않는 카테고리 조회 시 예외 처리 추가
- [x] 존재하지 않는 게시글 상세 조회 시 예외 처리 추가
- [x] 게시글 목록 응답 DTO와 상세 응답 DTO 분리
- [x] 익명 게시글 작성자 응답 시 null로 반환 처리
- [x] `PostMapper` 에 목록/상세 매핑 로직 추가
- [x] `PostController` 조회 API Swagger 문서 추가
- [x] 게시글 조회 단위 테스트 작성
- [x] 게시글 조회 e2e 테스트 작성
