### PR TITLE
게시글 수정 API 구현

### DIFF
--- a/migrations/1775715869089-AddIsAnonymousInPost.ts
+++ b/migrations/1775715869089-AddIsAnonymousInPost.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsAnonymousInPost1775715869089 implements MigrationInterface {
+    name = 'AddIsAnonymousInPost1775715869089'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "posts" ADD "is_anonymous" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "posts" DROP COLUMN "is_anonymous"`);
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:room": "jest --testPathPatterns=src/rooms --coverage --collectCoverageFrom=src/rooms/**",
-    "test:post": "jest --testPathPatterns=src/posts --coverage --collectCoverageFrom=src/posts/**",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d ./src/data-source.ts",
     "migration:create": "typeorm migration:create",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d ./src/data-source.ts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:room": "jest --testPathPatterns=src/rooms --coverage --collectCoverageFrom=src/rooms/**",
+    "test:post": "jest --testPathPatterns=src/posts --coverage --collectCoverageFrom=src/posts/**",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d ./src/data-source.ts",
     "migration:create": "typeorm migration:create",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d ./src/data-source.ts",

--- a/src/post-categories/post-categories.module.ts
+++ b/src/post-categories/post-categories.module.ts
@@ -9,5 +9,6 @@ import { PostCategoryRepository } from './post-categories.repository';
   imports: [TypeOrmModule.forFeature([PostCategory])],
   controllers: [PostCategoryController],
   providers: [PostCategoryService, PostCategoryRepository],
+  exports: [PostCategoryService],
 })
 export class PostCategoryModule {}

--- a/src/post-categories/post-categories.repository.ts
+++ b/src/post-categories/post-categories.repository.ts
@@ -17,4 +17,12 @@ export class PostCategoryRepository {
       },
     });
   }
+
+  async findPostCategoryById(categoryId: number): Promise<PostCategory | null> {
+    return await this.postCategoryRepository.findOne({
+      where: {
+        id: categoryId,
+      },
+    });
+  }
 }

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostCategoryRepository } from './post-categories.repository';
 import { PostCategory } from './entities/post-category.entity';
 
@@ -8,5 +8,12 @@ export class PostCategoryService {
 
   async findPostCategories(): Promise<PostCategory[]> {
     return await this.postCategoryRepository.findPostCategories();
+  }
+
+  async findPostCategoryById(categoryId: number): Promise<PostCategory> {
+    const category = await this.postCategoryRepository.findPostCategoryById(categoryId);
+    if (!category) throw new NotFoundException('존재하지 않은 카테고리입니다.');
+
+    return category;
   }
 }

--- a/src/post-categories/post-categories.service.ts
+++ b/src/post-categories/post-categories.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PostCategoryRepository } from './post-categories.repository';
 import { PostCategory } from './entities/post-category.entity';
 
@@ -10,10 +10,7 @@ export class PostCategoryService {
     return await this.postCategoryRepository.findPostCategories();
   }
 
-  async findPostCategoryById(categoryId: number): Promise<PostCategory> {
-    const category = await this.postCategoryRepository.findPostCategoryById(categoryId);
-    if (!category) throw new NotFoundException('존재하지 않은 카테고리입니다.');
-
-    return category;
+  async findPostCategoryById(categoryId: number): Promise<PostCategory | null> {
+    return await this.postCategoryRepository.findPostCategoryById(categoryId);
   }
 }

--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -1,0 +1,4 @@
+export const POST_CONSTANTS = {
+  MAX_TITLE: 50,
+  MAX_CONTENTS: 1000,
+};

--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -2,3 +2,8 @@ export const POST_CONSTANTS = {
   MAX_TITLE: 50,
   MAX_CONTENTS: 1000,
 };
+
+export const PAGINATION_CONSTANTS = {
+  MAX_LIMIT: 200,
+  DEFAULT_LIMIT: 20,
+};

--- a/src/posts/dtos/create-post.dto.ts
+++ b/src/posts/dtos/create-post.dto.ts
@@ -1,10 +1,36 @@
-import { PickType } from '@nestjs/mapped-types';
-import { Post } from '../entities/post.entity';
+import { POST_CONSTANTS } from '../constants/post.constant';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsNotEmpty, IsPositive, IsString, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
 
-export class CreatePostDto extends PickType(Post, ['title', 'content', 'category']) {
-  //  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  // @ApiProperty({ example: '밥 같이 먹을 사람' })
-  // @IsString()
-  // @IsNotEmpty()
-  // @MaxLength(ROOM_CONSTANTS.TITLE_MAX_LENGTH)
+export class CreatePostDto {
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @ApiProperty({ example: '학생식당 돈까스 맛있어요' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(POST_CONSTANTS.MAX_TITLE)
+  title: string;
+
+  @ApiProperty({
+    example: `오늘 점심에 학생식당 돈까스 먹었는데 진짜 너무 맛있었어요. 소스가 특히 맛있었어요.`,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(POST_CONSTANTS.MAX_CONTENTS)
+  content: string;
+
+  @ApiProperty({
+    example: 1,
+  })
+  @IsInt()
+  @IsNotEmpty()
+  @IsPositive()
+  categoryId: number;
+
+  @ApiProperty({
+    example: false,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isAnonymous: boolean;
 }

--- a/src/posts/dtos/find-posts-query.dto.ts
+++ b/src/posts/dtos/find-posts-query.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, Max, Min } from 'class-validator';
+import { PAGINATION_CONSTANTS } from '../constants/post.constant';
+
+export class FindPostsQueryDto {
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  cursor?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: PAGINATION_CONSTANTS.MAX_LIMIT })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
+  limit?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  categoryId?: number;
+}

--- a/src/posts/dtos/response-post.dto.ts
+++ b/src/posts/dtos/response-post.dto.ts
@@ -1,8 +1,12 @@
+import { PickType } from '@nestjs/mapped-types';
 import { ApiProperty } from '@nestjs/swagger';
 import { PostCategory } from 'src/post-categories/entities/post-category.entity';
 
-export class UserNameDto {
+export class PostAuthorDto {
+  @ApiProperty()
   id: number;
+
+  @ApiProperty()
   nickname: string;
 }
 
@@ -22,10 +26,10 @@ export class ResponsePostDetailDto {
   @ApiProperty()
   commentCount: number;
 
-  @ApiProperty()
-  user: UserNameDto | null;
+  @ApiProperty({ type: () => PostAuthorDto, nullable: true })
+  user: PostAuthorDto | null;
 
-  @ApiProperty()
+  @ApiProperty({ type: () => PostCategory })
   category: PostCategory;
 
   @ApiProperty()
@@ -36,4 +40,25 @@ export class ResponsePostDetailDto {
 
   @ApiProperty()
   createdAt: string;
+}
+
+export class ResponsePostListItemDto extends PickType(ResponsePostDetailDto, [
+  'id',
+  'title',
+  'createdAt',
+  'likeCount',
+  'viewCount',
+  'commentCount',
+  'user',
+]) {}
+
+export class ResponsePostListDto {
+  @ApiProperty({ type: () => [ResponsePostListItemDto] })
+  items: ResponsePostListItemDto[];
+
+  @ApiProperty({ nullable: true })
+  nextCursor: number | null;
+
+  @ApiProperty()
+  hasNext: boolean;
 }

--- a/src/posts/dtos/response-post.dto.ts
+++ b/src/posts/dtos/response-post.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostCategory } from 'src/post-categories/entities/post-category.entity';
+
+export class UserNameDto {
+  id: number;
+  nickname: string;
+}
+
+export class ResponsePostDetailDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  viewCount: number;
+
+  @ApiProperty()
+  commentCount: number;
+
+  @ApiProperty()
+  user: UserNameDto | null;
+
+  @ApiProperty()
+  category: PostCategory;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  isAnonymous: boolean;
+
+  @ApiProperty()
+  createdAt: string;
+}

--- a/src/posts/dtos/update-post.dto.ts
+++ b/src/posts/dtos/update-post.dto.ts
@@ -1,0 +1,8 @@
+import { OmitType, PartialType } from '@nestjs/mapped-types';
+import { CreatePostDto } from './create-post.dto';
+
+export class UpdatePostDto extends PartialType(CreatePostDto) {}
+
+export class UpdatePostPayloadDto extends OmitType(UpdatePostDto, ['categoryId']) {
+  category?: { id: number };
+}

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -38,6 +38,12 @@ export class Post extends BaseTableEntity {
   })
   commentCount: number;
 
+  @Column({
+    default: false,
+    name: 'is_anonymous',
+  })
+  isAnonymous: boolean;
+
   @OneToMany(() => Comment, (comment) => comment.post)
   comments: Comment[];
 

--- a/src/posts/mappers/post-mapper.ts
+++ b/src/posts/mappers/post-mapper.ts
@@ -1,24 +1,47 @@
 import { User } from 'src/users/entities/user.entity';
-import { ResponsePostDetailDto, UserNameDto } from '../dtos/response-post.dto';
+import {
+  PostAuthorDto,
+  ResponsePostDetailDto,
+  ResponsePostListDto,
+  ResponsePostListItemDto,
+} from '../dtos/response-post.dto';
 import { Post } from '../entities/post.entity';
 
 export class PostMapper {
-  static toDetailDto(post: Post): ResponsePostDetailDto {
+  static toListDto(
+    posts: Post[],
+    nextCursor: number | null,
+    hasNext: boolean,
+  ): ResponsePostListDto {
     return {
-      id: post.id,
-      title: post.title,
-      content: post.content,
-      viewCount: post.viewCount,
-      commentCount: post.commentCount,
-      user: post.isAnonymous ? null : this.toUserDto(post.user),
-      category: post.category,
-      likeCount: post.likeCount,
-      isAnonymous: post.isAnonymous,
-      createdAt: post.createdAt,
+      items: posts.map((post) => this.toListItemDto(post)),
+      nextCursor,
+      hasNext,
     };
   }
 
-  static toUserDto(user: User): UserNameDto {
+  static toListItemDto(post: Post): ResponsePostListItemDto {
+    return {
+      id: post.id,
+      title: post.title,
+      viewCount: post.viewCount,
+      likeCount: post.likeCount,
+      commentCount: post.commentCount,
+      createdAt: post.createdAt,
+      user: post.isAnonymous ? null : this.toPostAuthorDto(post.user),
+    };
+  }
+
+  static toDetailDto(post: Post): ResponsePostDetailDto {
+    return {
+      ...this.toListItemDto(post),
+      content: post.content,
+      category: post.category,
+      isAnonymous: post.isAnonymous,
+    };
+  }
+
+  static toPostAuthorDto(user: User): PostAuthorDto {
     return {
       id: user.id,
       nickname: user.nickname,

--- a/src/posts/mappers/post-mapper.ts
+++ b/src/posts/mappers/post-mapper.ts
@@ -1,0 +1,27 @@
+import { User } from 'src/users/entities/user.entity';
+import { ResponsePostDetailDto, UserNameDto } from '../dtos/response-post.dto';
+import { Post } from '../entities/post.entity';
+
+export class PostMapper {
+  static toDetailDto(post: Post): ResponsePostDetailDto {
+    return {
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      viewCount: post.viewCount,
+      commentCount: post.commentCount,
+      user: post.isAnonymous ? null : this.toUserDto(post.user),
+      category: post.category,
+      likeCount: post.likeCount,
+      isAnonymous: post.isAnonymous,
+      createdAt: post.createdAt,
+    };
+  }
+
+  static toUserDto(user: User): UserNameDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,9 +1,13 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
+  ApiParam,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -12,9 +16,15 @@ import { CreatePostDto } from './dtos/create-post.dto';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from 'src/auth/interfaces/jwt-payload.interface';
 import { Authenticated } from 'src/auth/decorators/authenticated.decorator';
-import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import {
+  ResponsePostDetailDto,
+  ResponsePostListDto,
+  ResponsePostListItemDto,
+} from './dtos/response-post.dto';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 @ApiTags('Post')
+@ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}
@@ -31,5 +41,26 @@ export class PostController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostDetailDto> {
     return await this.postService.createPost(createPostDto, user.userId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: '게시글 목록 조회' })
+  @ApiQuery({ name: 'cursor', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'categoryId', required: false, type: Number })
+  @ApiOkResponse({ type: ResponsePostListDto })
+  @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })
+  async findPosts(@Query() query: FindPostsQueryDto): Promise<ResponsePostListDto> {
+    return await this.postService.findPosts(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '게시글 상세 조회' })
+  @ApiParam({ name: 'id', description: '조회할 게시글 ID', type: Number })
+  @ApiOkResponse({ type: ResponsePostDetailDto })
+  @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
+  async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {
+    return await this.postService.findPostById(postId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
+  ApiBody,
   ApiCreatedResponse,
   ApiExtraModels,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -22,6 +24,7 @@ import {
   ResponsePostListItemDto,
 } from './dtos/response-post.dto';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { UpdatePostDto } from './dtos/update-post.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -62,5 +65,25 @@ export class PostController {
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
   async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {
     return await this.postService.findPostById(postId);
+  }
+
+  @Patch(':id')
+  @Authenticated()
+  @ApiOperation({ summary: '게시글 수정' })
+  @ApiParam({ name: 'id', description: '수정할 게시글 ID', type: Number })
+  @ApiBody({ type: UpdatePostDto })
+  @ApiOkResponse({ type: ResponsePostDetailDto })
+  @ApiBadRequestResponse({ description: '수정 요청 값이 올바르지 않거나 수정할 값이 없는 경우' })
+  @ApiForbiddenResponse({ description: '작성자가 아닌 사용자가 수정을 시도한 경우' })
+  @ApiNotFoundResponse({
+    description: '존재하지 않는 게시글 또는 카테고리로 수정을 시도한 경우',
+  })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async updatePost(
+    @Param('id', ParseIntPipe) postId: number,
+    @Body() updatePostDto: UpdatePostDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ResponsePostDetailDto> {
+    return await this.postService.updatePost(updatePostDto, postId, user.userId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -53,7 +53,6 @@ export class PostController {
 
   @Get(':id')
   @ApiOperation({ summary: '게시글 상세 조회' })
-  @ApiParam({ name: 'id', description: '조회할 게시글 ID', type: Number })
   @ApiOkResponse({ type: ResponsePostDetailDto })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
   async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -70,7 +80,6 @@ export class PostController {
   @Patch(':id')
   @Authenticated()
   @ApiOperation({ summary: '게시글 수정' })
-  @ApiParam({ name: 'id', description: '수정할 게시글 ID', type: Number })
   @ApiBody({ type: UpdatePostDto })
   @ApiOkResponse({ type: ResponsePostDetailDto })
   @ApiBadRequestResponse({ description: '수정 요청 값이 올바르지 않거나 수정할 값이 없는 경우' })
@@ -84,6 +93,9 @@ export class PostController {
     @Body() updatePostDto: UpdatePostDto,
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostDetailDto> {
+    if (Object.keys(updatePostDto).length < 1)
+      throw new BadRequestException('수정할 값이 없습니다.');
+
     return await this.postService.updatePost(updatePostDto, postId, user.userId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -7,7 +7,6 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
-  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -45,9 +44,6 @@ export class PostController {
 
   @Get()
   @ApiOperation({ summary: '게시글 목록 조회' })
-  @ApiQuery({ name: 'cursor', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'categoryId', required: false, type: Number })
   @ApiOkResponse({ type: ResponsePostListDto })
   @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
   @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -97,6 +97,8 @@ export class PostController {
     if (Object.keys(updatePostDto).length < 1)
       throw new BadRequestException('수정할 값이 없습니다.');
 
-    return await this.postService.updatePost(updatePostDto, postId, user.userId);
+    const updatedPost = await this.postService.updatePost(updatePostDto, postId, user.userId);
+
+    return PostMapper.toDetailDto(updatedPost);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -2,7 +2,6 @@ import { Body, Controller, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
-  ApiNotFoundResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -24,7 +23,7 @@ export class PostController {
   @ApiOperation({ summary: '게시글 작성' })
   @ApiCreatedResponse({ type: ResponsePostDetailDto })
   @ApiBadRequestResponse({ description: '게시글 작성 요청 값이 올바르지 않은 경우' })
-  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
+  @ApiBadRequestResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
   @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async createPost(
     @Body() createPostDto: CreatePostDto,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,7 +6,6 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -21,6 +20,7 @@ import {
   ResponsePostListItemDto,
 } from './dtos/response-post.dto';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { PostMapper } from './mappers/post-mapper';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -39,7 +39,9 @@ export class PostController {
     @Body() createPostDto: CreatePostDto,
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostDetailDto> {
-    return await this.postService.createPost(createPostDto, user.userId);
+    const createdPost = await this.postService.createPost(createPostDto, user.userId);
+
+    return PostMapper.toDetailDto(createdPost);
   }
 
   @Get()
@@ -48,7 +50,9 @@ export class PostController {
   @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
   @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 조회하려는 경우' })
   async findPosts(@Query() query: FindPostsQueryDto): Promise<ResponsePostListDto> {
-    return await this.postService.findPosts(query);
+    const { items, nextCursor, hasNext } = await this.postService.findPosts(query);
+
+    return PostMapper.toListDto(items, nextCursor, hasNext);
   }
 
   @Get(':id')
@@ -56,6 +60,8 @@ export class PostController {
   @ApiOkResponse({ type: ResponsePostDetailDto })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글을 조회하려는 경우' })
   async findPostById(@Param('id', ParseIntPipe) postId: number): Promise<ResponsePostDetailDto> {
-    return await this.postService.findPostById(postId);
+    const post = await this.postService.findPostById(postId);
+
+    return PostMapper.toDetailDto(post);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,12 +1,35 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { PostService } from './posts.service';
-import { Post } from '@nestjs/common';
 import { CreatePostDto } from './dtos/create-post.dto';
+import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/auth/interfaces/jwt-payload.interface';
+import { Authenticated } from 'src/auth/decorators/authenticated.decorator';
+import { ResponsePostDetailDto } from './dtos/response-post.dto';
 
+@ApiTags('Post')
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}
 
+  @Authenticated()
   @Post()
-  async createPost(createPostDto: CreatePostDto): Promise<ResponsePostDetailDto> {}
+  @ApiOperation({ summary: '게시글 작성' })
+  @ApiCreatedResponse({ type: ResponsePostDetailDto })
+  @ApiBadRequestResponse({ description: '게시글 작성 요청 값이 올바르지 않은 경우' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 카테고리로 게시글을 작성하려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async createPost(
+    @Body() createPostDto: CreatePostDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ResponsePostDetailDto> {
+    return await this.postService.createPost(createPostDto, user.userId);
+  }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -5,9 +5,10 @@ import { PostLike } from './entities/post-like.entity';
 import { PostController } from './posts.controller';
 import { PostService } from './posts.service';
 import { PostRepository } from './posts.repository';
+import { PostCategoryModule } from 'src/post-categories/post-categories.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostLike])],
+  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule],
   controllers: [PostController],
   providers: [PostService, PostRepository],
 })

--- a/src/posts/posts.repository.spec.ts
+++ b/src/posts/posts.repository.spec.ts
@@ -2,15 +2,17 @@ import { Repository } from 'typeorm';
 import { PostRepository } from './posts.repository';
 import { Post } from './entities/post.entity';
 import { CreatePostDto } from './dtos/create-post.dto';
+import { UpdatePostPayloadDto } from './dtos/update-post.dto';
 
 describe('PostRepository', () => {
   let postRepository: PostRepository;
-  let postOrmRepository: Pick<Repository<Post>, 'save' | 'findOne'>;
+  let postOrmRepository: Pick<Repository<Post>, 'save' | 'findOne' | 'update'>;
 
   beforeEach(() => {
     postOrmRepository = {
       save: jest.fn(),
       findOne: jest.fn(),
+      update: jest.fn(),
     };
 
     postRepository = new PostRepository(postOrmRepository as Repository<Post>);
@@ -65,6 +67,26 @@ describe('PostRepository', () => {
           user: true,
         },
       });
+    });
+  });
+
+  describe('updatePost', () => {
+    it('postId와 수정 payload로 update를 호출', async () => {
+      const updatePostPayload: UpdatePostPayloadDto = {
+        title: '수정된 제목',
+        category: { id: 2 },
+        isAnonymous: true,
+      };
+      const updateResult = {
+        affected: 1,
+      };
+
+      (postOrmRepository.update as jest.Mock).mockResolvedValue(updateResult);
+
+      const result = await postRepository.updatePost(1, updatePostPayload);
+
+      expect(result).toEqual(updateResult);
+      expect(postOrmRepository.update).toHaveBeenCalledWith(1, updatePostPayload);
     });
   });
 });

--- a/src/posts/posts.repository.spec.ts
+++ b/src/posts/posts.repository.spec.ts
@@ -1,0 +1,70 @@
+import { Repository } from 'typeorm';
+import { PostRepository } from './posts.repository';
+import { Post } from './entities/post.entity';
+import { CreatePostDto } from './dtos/create-post.dto';
+
+describe('PostRepository', () => {
+  let postRepository: PostRepository;
+  let postOrmRepository: Pick<Repository<Post>, 'save' | 'findOne'>;
+
+  beforeEach(() => {
+    postOrmRepository = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    postRepository = new PostRepository(postOrmRepository as Repository<Post>);
+  });
+
+  describe('createPost', () => {
+    it('작성 DTO와 userId로 save를 호출', async () => {
+      const createPostDto: CreatePostDto = {
+        title: '학생식당 돈까스 맛있어요',
+        content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+        categoryId: 1,
+        isAnonymous: false,
+      };
+      const savedPost = {
+        id: 1,
+        ...createPostDto,
+      };
+
+      (postOrmRepository.save as jest.Mock).mockResolvedValue(savedPost);
+
+      const result = await postRepository.createPost(createPostDto, 7);
+
+      expect(result).toEqual(savedPost);
+      expect(postOrmRepository.save).toHaveBeenCalledWith({
+        title: createPostDto.title,
+        content: createPostDto.content,
+        isAnonymous: createPostDto.isAnonymous,
+        category: { id: createPostDto.categoryId },
+        user: { id: 7 },
+      });
+    });
+  });
+
+  describe('findPostById', () => {
+    it('postId와 relations 조건으로 findOne을 호출', async () => {
+      const post = {
+        id: 1,
+        title: '게시글',
+      };
+
+      (postOrmRepository.findOne as jest.Mock).mockResolvedValue(post);
+
+      const result = await postRepository.findPostById(1);
+
+      expect(result).toEqual(post);
+      expect(postOrmRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+        },
+        relations: {
+          category: true,
+          user: true,
+        },
+      });
+    });
+  });
+});

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
-import { FindOptionsWhere, LessThan, Repository } from 'typeorm';
+import { FindOptionsWhere, LessThan, Repository, UpdateResult } from 'typeorm';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { UpdatePostPayloadDto } from './dtos/update-post.dto';
 
 @Injectable()
 export class PostRepository {
@@ -51,5 +52,9 @@ export class PostRepository {
       },
       take: limit + 1,
     });
+  }
+
+  async updatePost(postId: number, updatePostPayload: UpdatePostPayloadDto): Promise<UpdateResult> {
+    return await this.postRepository.update(postId, updatePostPayload);
   }
 }

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
 import { Repository } from 'typeorm';
+import { CreatePostDto } from './dtos/create-post.dto';
 
 @Injectable()
 export class PostRepository {
@@ -9,4 +10,26 @@ export class PostRepository {
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
   ) {}
+
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<Post> {
+    return await this.postRepository.save({
+      title: createPostDto.title,
+      content: createPostDto.content,
+      isAnonymous: createPostDto.isAnonymous,
+      category: { id: createPostDto.categoryId },
+      user: { id: userId },
+    });
+  }
+
+  async findPostById(postId: number): Promise<Post | null> {
+    return await this.postRepository.findOne({
+      where: {
+        id: postId,
+      },
+      relations: {
+        category: true,
+        user: true,
+      },
+    });
+  }
 }

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, LessThan, Repository } from 'typeorm';
 import { CreatePostDto } from './dtos/create-post.dto';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 @Injectable()
 export class PostRepository {
@@ -30,6 +31,25 @@ export class PostRepository {
         category: true,
         user: true,
       },
+    });
+  }
+
+  async findPosts(query: FindPostsQueryDto, limit: number): Promise<Post[]> {
+    const where: FindOptionsWhere<Post> = {};
+
+    if (query.categoryId !== undefined) where.category = { id: query.categoryId };
+    if (query.cursor !== undefined) where.id = LessThan(query.cursor);
+
+    return await this.postRepository.find({
+      where,
+      relations: {
+        user: true,
+        category: true,
+      },
+      order: {
+        id: 'DESC',
+      },
+      take: limit + 1,
     });
   }
 }

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1,11 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { PostService } from './posts.service';
 import { PostRepository } from './posts.repository';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { UpdatePostDto } from './dtos/update-post.dto';
 
 const createPostDto: CreatePostDto = {
   title: '학생식당 돈까스 맛있어요',
@@ -78,6 +79,7 @@ const mockPostRepository = {
   createPost: jest.fn(),
   findPostById: jest.fn(),
   findPosts: jest.fn(),
+  updatePost: jest.fn(),
 };
 
 const mockPostCategoryService = {
@@ -209,6 +211,139 @@ describe('PostService', () => {
       await expect(postService.findPostById(999)).rejects.toThrow(NotFoundException);
 
       expect(mockPostRepository.findPostById).toHaveBeenCalledWith(999);
+    });
+  });
+
+  describe('updatePost', () => {
+    it('작성자가 수정하면 카테고리를 검증하고 수정 후 상세 정보를 반환', async () => {
+      const updatePostDto: UpdatePostDto = {
+        title: '수정된 제목',
+        content: '수정된 내용',
+        categoryId: 2,
+        isAnonymous: true,
+      };
+      const updatedCategory = {
+        id: 2,
+        name: '정보',
+      };
+      const updatedPostEntity = {
+        ...mockPostEntity,
+        title: updatePostDto.title,
+        content: updatePostDto.content,
+        isAnonymous: true,
+        category: updatedCategory,
+      };
+      const updatedPostDetailDto = {
+        ...mockPostDetailDto,
+        title: updatePostDto.title,
+        content: updatePostDto.content,
+        isAnonymous: true,
+        category: updatedCategory,
+        user: null,
+      };
+
+      mockPostRepository.findPostById
+        .mockResolvedValueOnce(mockPostEntity)
+        .mockResolvedValueOnce(updatedPostEntity);
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(updatedCategory);
+      mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
+      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
+
+      const result = await postService.updatePost(updatePostDto, 3, 7);
+
+      expect(result).toEqual(updatedPostDetailDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
+        updatePostDto.categoryId,
+      );
+      expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
+        title: '수정된 제목',
+        content: '수정된 내용',
+        isAnonymous: true,
+        category: { id: 2 },
+      });
+      expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(1, 3);
+      expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(2, 3);
+      expect(toDetailDtoSpy).toHaveBeenCalledWith(updatedPostEntity);
+    });
+
+    it('작성자가 아니면 ForbiddenException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+
+      await expect(postService.updatePost({ title: '수정 시도' }, 3, 8)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockPostRepository.updatePost).not.toHaveBeenCalled();
+    });
+
+    it('수정할 값이 없으면 BadRequestException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+
+      await expect(postService.updatePost({}, 3, 7)).rejects.toThrow(BadRequestException);
+
+      expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
+      expect(mockPostRepository.updatePost).not.toHaveBeenCalled();
+    });
+
+    it('카테고리 없이 부분 수정하면 카테고리 검증 없이 수정한다', async () => {
+      const updatePostDto: UpdatePostDto = {
+        title: '제목만 수정',
+      };
+      const updatedPostEntity = {
+        ...mockPostEntity,
+        title: '제목만 수정',
+      };
+      const updatedPostDetailDto = {
+        ...mockPostDetailDto,
+        title: '제목만 수정',
+      };
+
+      mockPostRepository.findPostById
+        .mockResolvedValueOnce(mockPostEntity)
+        .mockResolvedValueOnce(updatedPostEntity);
+      mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
+      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
+
+      const result = await postService.updatePost(updatePostDto, 3, 7);
+
+      expect(result).toEqual(updatedPostDetailDto);
+      expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
+      expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
+        title: '제목만 수정',
+      });
+    });
+
+    it('카테고리만 수정하면 category payload만 포함해 수정한다', async () => {
+      const updatePostDto: UpdatePostDto = {
+        categoryId: 2,
+      };
+      const updatedCategory = {
+        id: 2,
+        name: '정보',
+      };
+      const updatedPostEntity = {
+        ...mockPostEntity,
+        category: updatedCategory,
+      };
+      const updatedPostDetailDto = {
+        ...mockPostDetailDto,
+        category: updatedCategory,
+      };
+
+      mockPostRepository.findPostById
+        .mockResolvedValueOnce(mockPostEntity)
+        .mockResolvedValueOnce(updatedPostEntity);
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(updatedCategory);
+      mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
+      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
+
+      const result = await postService.updatePost(updatePostDto, 3, 7);
+
+      expect(result).toEqual(updatedPostDetailDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(2);
+      expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
+        category: { id: 2 },
+      });
     });
   });
 });

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -4,7 +4,6 @@ import { PostService } from './posts.service';
 import { PostRepository } from './posts.repository';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
 import { CreatePostDto } from './dtos/create-post.dto';
-import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 const createPostDto: CreatePostDto = {
@@ -39,41 +38,6 @@ const mockPostEntity = {
   },
 };
 
-const mockPostDetailDto = {
-  id: 3,
-  title: createPostDto.title,
-  content: createPostDto.content,
-  viewCount: 0,
-  commentCount: 0,
-  likeCount: 0,
-  isAnonymous: false,
-  createdAt: '2026-04-09T00:00:00.000Z',
-  category: mockCategory,
-  user: {
-    id: 7,
-    nickname: 'writer',
-  },
-};
-
-const mockPostListDto = {
-  items: [
-    {
-      id: 3,
-      title: createPostDto.title,
-      viewCount: 0,
-      likeCount: 0,
-      commentCount: 0,
-      createdAt: '2026-04-09T00:00:00.000Z',
-      user: {
-        id: 7,
-        nickname: 'writer',
-      },
-    },
-  ],
-  nextCursor: null,
-  hasNext: false,
-};
-
 const mockPostRepository = {
   createPost: jest.fn(),
   findPostById: jest.fn(),
@@ -86,14 +50,10 @@ const mockPostCategoryService = {
 
 describe('PostService', () => {
   let postService: PostService;
-  let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
-  let toListDtoSpy: jest.SpiedFunction<typeof PostMapper.toListDto>;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
-    toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
-    toListDtoSpy = jest.spyOn(PostMapper, 'toListDto');
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -117,17 +77,15 @@ describe('PostService', () => {
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
       mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
       mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
-      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
 
       const result = await postService.createPost(createPostDto, 7);
 
-      expect(result).toEqual(mockPostDetailDto);
+      expect(result).toEqual(mockPostEntity);
       expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
         createPostDto.categoryId,
       );
       expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
       expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
-      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
     });
 
     it('생성 후 게시글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
@@ -154,14 +112,16 @@ describe('PostService', () => {
 
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
       mockPostRepository.findPosts.mockResolvedValue([mockPostEntity]);
-      toListDtoSpy.mockReturnValue(mockPostListDto);
 
       const result = await postService.findPosts(query);
 
-      expect(result).toEqual(mockPostListDto);
+      expect(result).toEqual({
+        items: [mockPostEntity],
+        nextCursor: null,
+        hasNext: false,
+      });
       expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(query.categoryId);
       expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 20);
-      expect(toListDtoSpy).toHaveBeenCalledWith([mockPostEntity], null, false);
     });
 
     it('다음 페이지가 있으면 limit 만큼만 잘라 nextCursor와 함께 반환', async () => {
@@ -173,33 +133,27 @@ describe('PostService', () => {
         id: 1,
       };
       const foundPosts = [mockPostEntity, { ...mockPostEntity, id: 2 }, thirdPost];
-      const paginatedResult = {
-        ...mockPostListDto,
-        nextCursor: 2,
-        hasNext: true,
-      };
-
       mockPostRepository.findPosts.mockResolvedValue(foundPosts);
-      toListDtoSpy.mockReturnValue(paginatedResult);
 
       const result = await postService.findPosts(query);
 
-      expect(result).toEqual(paginatedResult);
+      expect(result).toEqual({
+        items: foundPosts.slice(0, 2),
+        nextCursor: 2,
+        hasNext: true,
+      });
       expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
       expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 2);
-      expect(toListDtoSpy).toHaveBeenCalledWith(foundPosts.slice(0, 2), 2, true);
     });
   });
 
   describe('findPostById', () => {
     it('게시글 상세 정보를 반환', async () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
-      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
 
       const result = await postService.findPostById(3);
 
-      expect(result).toEqual(mockPostDetailDto);
-      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+      expect(result).toEqual(mockPostEntity);
     });
 
     it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PostService } from './posts.service';
+import { PostRepository } from './posts.repository';
+import { PostCategoryService } from 'src/post-categories/post-categories.service';
+import { CreatePostDto } from './dtos/create-post.dto';
+import { PostMapper } from './mappers/post-mapper';
+
+const createPostDto: CreatePostDto = {
+  title: '학생식당 돈까스 맛있어요',
+  content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+  categoryId: 1,
+  isAnonymous: false,
+};
+
+const mockCategory = {
+  id: 1,
+  name: '자유',
+};
+
+const mockCreatedPost = {
+  id: 3,
+};
+
+const mockPostEntity = {
+  id: 3,
+  title: createPostDto.title,
+  content: createPostDto.content,
+  viewCount: 0,
+  commentCount: 0,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-09T00:00:00.000Z',
+  category: mockCategory,
+  user: {
+    id: 7,
+    nickname: 'writer',
+  },
+};
+
+const mockPostDetailDto = {
+  id: 3,
+  title: createPostDto.title,
+  content: createPostDto.content,
+  viewCount: 0,
+  commentCount: 0,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-09T00:00:00.000Z',
+  category: mockCategory,
+  user: {
+    id: 7,
+    nickname: 'writer',
+  },
+};
+
+const mockPostRepository = {
+  createPost: jest.fn(),
+  findPostById: jest.fn(),
+};
+
+const mockPostCategoryService = {
+  findPostCategoryById: jest.fn(),
+};
+
+describe('PostService', () => {
+  let postService: PostService;
+  let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostService,
+        {
+          provide: PostRepository,
+          useValue: mockPostRepository,
+        },
+        {
+          provide: PostCategoryService,
+          useValue: mockPostCategoryService,
+        },
+      ],
+    }).compile();
+
+    postService = module.get<PostService>(PostService);
+  });
+
+  describe('createPost', () => {
+    it('카테고리를 검증하고 생성된 게시글 상세 정보를 반환', async () => {
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
+
+      const result = await postService.createPost(createPostDto, 7);
+
+      expect(result).toEqual(mockPostDetailDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
+        createPostDto.categoryId,
+      );
+      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+    });
+
+    it('생성 후 게시글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.createPost.mockResolvedValue(mockCreatedPost);
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(postService.createPost(createPostDto, 7)).rejects.toThrow(NotFoundException);
+
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
+        createPostDto.categoryId,
+      );
+      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+    });
+  });
+});

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -83,11 +83,14 @@ describe('PostService', () => {
       const result = await postService.createPost(createPostDto, 7);
 
       expect(result).toEqual(mockPostEntity);
-      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
-        createPostDto.categoryId,
-      );
-      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
-      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+    });
+
+    it('존재하지 않는 카테고리면 BadRequestException을 던진다', async () => {
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(null);
+
+      await expect(postService.createPost(createPostDto, 7)).rejects.toThrow(BadRequestException);
+
+      expect(mockPostRepository.createPost).not.toHaveBeenCalled();
     });
 
     it('생성 후 게시글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
@@ -96,12 +99,6 @@ describe('PostService', () => {
       mockPostRepository.findPostById.mockResolvedValue(null);
 
       await expect(postService.createPost(createPostDto, 7)).rejects.toThrow(NotFoundException);
-
-      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
-        createPostDto.categoryId,
-      );
-      expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
-      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
     });
   });
 
@@ -122,8 +119,6 @@ describe('PostService', () => {
         nextCursor: null,
         hasNext: false,
       });
-      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(query.categoryId);
-      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 20);
     });
 
     it('다음 페이지가 있으면 limit 만큼만 잘라 nextCursor와 함께 반환', async () => {
@@ -145,7 +140,6 @@ describe('PostService', () => {
         hasNext: true,
       });
       expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
-      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 2);
     });
   });
 
@@ -162,8 +156,6 @@ describe('PostService', () => {
       mockPostRepository.findPostById.mockResolvedValue(null);
 
       await expect(postService.findPostById(999)).rejects.toThrow(NotFoundException);
-
-      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(999);
     });
   });
 
@@ -186,37 +178,21 @@ describe('PostService', () => {
         isAnonymous: true,
         category: updatedCategory,
       };
-      const updatedPostDetailDto = {
-        ...mockPostDetailDto,
-        title: updatePostDto.title,
-        content: updatePostDto.content,
-        isAnonymous: true,
-        category: updatedCategory,
-        user: null,
-      };
-
       mockPostRepository.findPostById
         .mockResolvedValueOnce(mockPostEntity)
         .mockResolvedValueOnce(updatedPostEntity);
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(updatedCategory);
       mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
-      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
 
       const result = await postService.updatePost(updatePostDto, 3, 7);
 
-      expect(result).toEqual(updatedPostDetailDto);
-      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(
-        updatePostDto.categoryId,
-      );
+      expect(result).toEqual(updatedPostEntity);
       expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
         title: '수정된 제목',
         content: '수정된 내용',
         isAnonymous: true,
         category: { id: 2 },
       });
-      expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(1, 3);
-      expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(2, 3);
-      expect(toDetailDtoSpy).toHaveBeenCalledWith(updatedPostEntity);
     });
 
     it('작성자가 아니면 ForbiddenException을 던진다', async () => {
@@ -229,15 +205,6 @@ describe('PostService', () => {
       expect(mockPostRepository.updatePost).not.toHaveBeenCalled();
     });
 
-    it('수정할 값이 없으면 BadRequestException을 던진다', async () => {
-      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
-
-      await expect(postService.updatePost({}, 3, 7)).rejects.toThrow(BadRequestException);
-
-      expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
-      expect(mockPostRepository.updatePost).not.toHaveBeenCalled();
-    });
-
     it('카테고리 없이 부분 수정하면 카테고리 검증 없이 수정한다', async () => {
       const updatePostDto: UpdatePostDto = {
         title: '제목만 수정',
@@ -246,20 +213,15 @@ describe('PostService', () => {
         ...mockPostEntity,
         title: '제목만 수정',
       };
-      const updatedPostDetailDto = {
-        ...mockPostDetailDto,
-        title: '제목만 수정',
-      };
 
       mockPostRepository.findPostById
         .mockResolvedValueOnce(mockPostEntity)
         .mockResolvedValueOnce(updatedPostEntity);
       mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
-      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
 
       const result = await postService.updatePost(updatePostDto, 3, 7);
 
-      expect(result).toEqual(updatedPostDetailDto);
+      expect(result).toEqual(updatedPostEntity);
       expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
       expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
         title: '제목만 수정',
@@ -278,25 +240,34 @@ describe('PostService', () => {
         ...mockPostEntity,
         category: updatedCategory,
       };
-      const updatedPostDetailDto = {
-        ...mockPostDetailDto,
-        category: updatedCategory,
-      };
 
       mockPostRepository.findPostById
         .mockResolvedValueOnce(mockPostEntity)
         .mockResolvedValueOnce(updatedPostEntity);
       mockPostCategoryService.findPostCategoryById.mockResolvedValue(updatedCategory);
       mockPostRepository.updatePost.mockResolvedValue({ affected: 1 });
-      toDetailDtoSpy.mockReturnValue(updatedPostDetailDto);
 
       const result = await postService.updatePost(updatePostDto, 3, 7);
 
-      expect(result).toEqual(updatedPostDetailDto);
-      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(2);
+      expect(result).toEqual(updatedPostEntity);
       expect(mockPostRepository.updatePost).toHaveBeenCalledWith(3, {
         category: { id: 2 },
       });
+    });
+
+    it('존재하지 않는 카테고리로 수정하면 BadRequestException을 던진다', async () => {
+      const updatePostDto: UpdatePostDto = {
+        categoryId: 999,
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(null);
+
+      await expect(postService.updatePost(updatePostDto, 3, 7)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockPostRepository.updatePost).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -5,6 +5,7 @@ import { PostRepository } from './posts.repository';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostMapper } from './mappers/post-mapper';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 
 const createPostDto: CreatePostDto = {
   title: '학생식당 돈까스 맛있어요',
@@ -54,9 +55,29 @@ const mockPostDetailDto = {
   },
 };
 
+const mockPostListDto = {
+  items: [
+    {
+      id: 3,
+      title: createPostDto.title,
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: '2026-04-09T00:00:00.000Z',
+      user: {
+        id: 7,
+        nickname: 'writer',
+      },
+    },
+  ],
+  nextCursor: null,
+  hasNext: false,
+};
+
 const mockPostRepository = {
   createPost: jest.fn(),
   findPostById: jest.fn(),
+  findPosts: jest.fn(),
 };
 
 const mockPostCategoryService = {
@@ -66,11 +87,13 @@ const mockPostCategoryService = {
 describe('PostService', () => {
   let postService: PostService;
   let toDetailDtoSpy: jest.SpiedFunction<typeof PostMapper.toDetailDto>;
+  let toListDtoSpy: jest.SpiedFunction<typeof PostMapper.toListDto>;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
     toDetailDtoSpy = jest.spyOn(PostMapper, 'toDetailDto');
+    toListDtoSpy = jest.spyOn(PostMapper, 'toListDto');
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -119,6 +142,73 @@ describe('PostService', () => {
       );
       expect(mockPostRepository.createPost).toHaveBeenCalledWith(createPostDto, 7);
       expect(mockPostRepository.findPostById).toHaveBeenCalledWith(mockCreatedPost.id);
+    });
+  });
+
+  describe('findPosts', () => {
+    it('카테고리 조건이 있으면 검증 후 게시글 목록 반환', async () => {
+      const query: FindPostsQueryDto = {
+        categoryId: 1,
+        limit: 20,
+      };
+
+      mockPostCategoryService.findPostCategoryById.mockResolvedValue(mockCategory);
+      mockPostRepository.findPosts.mockResolvedValue([mockPostEntity]);
+      toListDtoSpy.mockReturnValue(mockPostListDto);
+
+      const result = await postService.findPosts(query);
+
+      expect(result).toEqual(mockPostListDto);
+      expect(mockPostCategoryService.findPostCategoryById).toHaveBeenCalledWith(query.categoryId);
+      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 20);
+      expect(toListDtoSpy).toHaveBeenCalledWith([mockPostEntity], null, false);
+    });
+
+    it('다음 페이지가 있으면 limit 만큼만 잘라 nextCursor와 함께 반환', async () => {
+      const query: FindPostsQueryDto = {
+        limit: 2,
+      };
+      const thirdPost = {
+        ...mockPostEntity,
+        id: 1,
+      };
+      const foundPosts = [mockPostEntity, { ...mockPostEntity, id: 2 }, thirdPost];
+      const paginatedResult = {
+        ...mockPostListDto,
+        nextCursor: 2,
+        hasNext: true,
+      };
+
+      mockPostRepository.findPosts.mockResolvedValue(foundPosts);
+      toListDtoSpy.mockReturnValue(paginatedResult);
+
+      const result = await postService.findPosts(query);
+
+      expect(result).toEqual(paginatedResult);
+      expect(mockPostCategoryService.findPostCategoryById).not.toHaveBeenCalled();
+      expect(mockPostRepository.findPosts).toHaveBeenCalledWith(query, 2);
+      expect(toListDtoSpy).toHaveBeenCalledWith(foundPosts.slice(0, 2), 2, true);
+    });
+  });
+
+  describe('findPostById', () => {
+    it('게시글 상세 정보를 반환', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPostEntity);
+      toDetailDtoSpy.mockReturnValue(mockPostDetailDto);
+
+      const result = await postService.findPostById(3);
+
+      expect(result).toEqual(mockPostDetailDto);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
+      expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(postService.findPostById(999)).rejects.toThrow(NotFoundException);
+
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(999);
     });
   });
 });

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -199,7 +199,6 @@ describe('PostService', () => {
       const result = await postService.findPostById(3);
 
       expect(result).toEqual(mockPostDetailDto);
-      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
       expect(toDetailDtoSpy).toHaveBeenCalledWith(mockPostEntity);
     });
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,7 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
+import { CreatePostDto } from './dtos/create-post.dto';
+import { PostCategoryService } from 'src/post-categories/post-categories.service';
+import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import { PostMapper } from './mappers/post-mapper';
 
 @Injectable()
 export class PostService {
-  constructor(private readonly postRepository: PostRepository) {}
+  constructor(
+    private readonly postRepository: PostRepository,
+    private readonly postCategoryService: PostCategoryService,
+  ) {}
+
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
+    const categoryId = createPostDto.categoryId;
+
+    await this.postCategoryService.findPostCategoryById(categoryId);
+
+    const createdPost = await this.postRepository.createPost(createPostDto, userId);
+
+    const post = await this.postRepository.findPostById(createdPost.id);
+
+    if (!post) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+
+    return PostMapper.toDetailDto(post);
+  }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -23,8 +23,7 @@ export class PostService {
   async createPost(createPostDto: CreatePostDto, userId: number): Promise<Post> {
     const categoryId = createPostDto.categoryId;
 
-    const existingCategory = await this.postCategoryService.findPostCategoryById(categoryId);
-    if (!existingCategory) throw new BadRequestException('존재하지 않는 카테고리입니다.');
+    await this.validateCategoryExists(categoryId);
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 
@@ -37,7 +36,7 @@ export class PostService {
 
   async findPosts(findPostsQuery: FindPostsQueryDto): Promise<FindPostsResult> {
     if (findPostsQuery.categoryId !== undefined)
-      await this.postCategoryService.findPostCategoryById(findPostsQuery.categoryId);
+      await this.validateCategoryExists(findPostsQuery.categoryId);
 
     const limit = findPostsQuery.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
     const posts = await this.postRepository.findPosts(findPostsQuery, limit);
@@ -52,17 +51,16 @@ export class PostService {
     };
   }
 
-  async findPostById(postId: number): Promise<ResponsePostDetailDto> {
-    const post = await this.findPostByIdOrThrow(postId);
-    return PostMapper.toDetailDto(post);
+  async findPostById(postId: number): Promise<Post> {
+    const post = await this.postRepository.findPostById(postId);
+
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    return post;
   }
 
-  async updatePost(
-    updatePostDto: UpdatePostDto,
-    postId: number,
-    userId: number,
-  ): Promise<ResponsePostDetailDto> {
-    const existingPost = await this.findPostByIdOrThrow(postId);
+  async updatePost(updatePostDto: UpdatePostDto, postId: number, userId: number): Promise<Post> {
+    const existingPost = await this.findPostById(postId);
 
     await this.validatePost(updatePostDto, userId, existingPost.user.id);
 
@@ -93,19 +91,13 @@ export class PostService {
       throw new ForbiddenException('게시글을 수정할 권한이 없습니다.');
 
     if (updatePostDto.categoryId !== undefined) {
-      const existingCategory = await this.postCategoryService.findPostCategoryById(
-        updatePostDto.categoryId,
-      );
-
-      if (!existingCategory) throw new NotFoundException('존재하지 않는 카테고리입니다.');
+      await this.validateCategoryExists(updatePostDto.categoryId);
     }
   }
 
-  private async findPostByIdOrThrow(postId: number): Promise<Post> {
-    const post = await this.postRepository.findPostById(postId);
+  private async validateCategoryExists(categoryId: number): Promise<void> {
+    const existingCategory = await this.postCategoryService.findPostCategoryById(categoryId);
 
-    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
-
-    return post;
+    if (!existingCategory) throw new BadRequestException('존재하지 않는 카테고리입니다.');
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -2,10 +2,10 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
-import { ResponsePostDetailDto, ResponsePostListDto } from './dtos/response-post.dto';
-import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 import { PAGINATION_CONSTANTS } from './constants/post.constant';
+import { Post } from './entities/post.entity';
+import { FindPostsResult } from './types/post.type';
 
 @Injectable()
 export class PostService {
@@ -14,7 +14,7 @@ export class PostService {
     private readonly postCategoryService: PostCategoryService,
   ) {}
 
-  async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
+  async createPost(createPostDto: CreatePostDto, userId: number): Promise<Post> {
     const categoryId = createPostDto.categoryId;
 
     await this.postCategoryService.findPostCategoryById(categoryId);
@@ -25,10 +25,10 @@ export class PostService {
 
     if (!newPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
 
-    return PostMapper.toDetailDto(newPostDetail);
+    return newPostDetail;
   }
 
-  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<ResponsePostListDto> {
+  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<FindPostsResult> {
     if (findPostsQuery.categoryId !== undefined)
       await this.postCategoryService.findPostCategoryById(findPostsQuery.categoryId);
 
@@ -38,14 +38,18 @@ export class PostService {
     const paginatedPosts = hasNext ? posts.slice(0, limit) : posts;
     const nextCursor = hasNext ? paginatedPosts[paginatedPosts.length - 1].id : null;
 
-    return PostMapper.toListDto(paginatedPosts, nextCursor, hasNext);
+    return {
+      items: paginatedPosts,
+      nextCursor,
+      hasNext,
+    };
   }
 
-  async findPostById(postId: number): Promise<ResponsePostDetailDto> {
+  async findPostById(postId: number): Promise<Post> {
     const post = await this.postRepository.findPostById(postId);
 
     if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
-    return PostMapper.toDetailDto(post);
+    return post;
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,9 +1,4 @@
-import {
-  BadRequestException,
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
@@ -85,14 +80,16 @@ export class PostService {
     currentUserId: number,
     authorId: number,
   ): Promise<void> {
-    if (Object.keys(updatePostDto).length < 1)
-      throw new BadRequestException('수정할 값이 없습니다.');
-
     if (authorId !== currentUserId)
       throw new ForbiddenException('게시글을 수정할 권한이 없습니다.');
 
-    if (updatePostDto.categoryId !== undefined)
-      await this.postCategoryService.findPostCategoryById(updatePostDto.categoryId);
+    if (updatePostDto.categoryId !== undefined) {
+      const existingCategory = await this.postCategoryService.findPostCategoryById(
+        updatePostDto.categoryId,
+      );
+
+      if (!existingCategory) throw new NotFoundException('존재하지 않는 카테고리입니다.');
+    }
   }
 
   private async findPostByIdOrThrow(postId: number): Promise<Post> {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -2,8 +2,10 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
-import { ResponsePostDetailDto } from './dtos/response-post.dto';
+import { ResponsePostDetailDto, ResponsePostListDto } from './dtos/response-post.dto';
 import { PostMapper } from './mappers/post-mapper';
+import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
+import { PAGINATION_CONSTANTS } from './constants/post.constant';
 
 @Injectable()
 export class PostService {
@@ -19,9 +21,30 @@ export class PostService {
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 
-    const post = await this.postRepository.findPostById(createdPost.id);
+    const newPostDetail = await this.postRepository.findPostById(createdPost.id);
 
-    if (!post) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+    if (!newPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+
+    return PostMapper.toDetailDto(newPostDetail);
+  }
+
+  async findPosts(findPostsQuery: FindPostsQueryDto): Promise<ResponsePostListDto> {
+    if (findPostsQuery.categoryId !== undefined)
+      await this.postCategoryService.findPostCategoryById(findPostsQuery.categoryId);
+
+    const limit = findPostsQuery.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
+    const posts = await this.postRepository.findPosts(findPostsQuery, limit);
+    const hasNext = posts.length > limit;
+    const paginatedPosts = hasNext ? posts.slice(0, limit) : posts;
+    const nextCursor = hasNext ? paginatedPosts[paginatedPosts.length - 1].id : null;
+
+    return PostMapper.toListDto(paginatedPosts, nextCursor, hasNext);
+  }
+
+  async findPostById(postId: number): Promise<ResponsePostDetailDto> {
+    const post = await this.postRepository.findPostById(postId);
+
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
     return PostMapper.toDetailDto(post);
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
@@ -15,7 +15,8 @@ export class PostService {
   async createPost(createPostDto: CreatePostDto, userId: number): Promise<ResponsePostDetailDto> {
     const categoryId = createPostDto.categoryId;
 
-    await this.postCategoryService.findPostCategoryById(categoryId);
+    const existingCategory = await this.postCategoryService.findPostCategoryById(categoryId);
+    if (!existingCategory) throw new BadRequestException('존재하지 않는 카테고리입니다.');
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PostRepository } from './posts.repository';
 import { CreatePostDto } from './dtos/create-post.dto';
 import { PostCategoryService } from 'src/post-categories/post-categories.service';
@@ -6,6 +11,8 @@ import { ResponsePostDetailDto, ResponsePostListDto } from './dtos/response-post
 import { PostMapper } from './mappers/post-mapper';
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 import { PAGINATION_CONSTANTS } from './constants/post.constant';
+import { Post } from './entities/post.entity';
+import { UpdatePostDto, UpdatePostPayloadDto } from './dtos/update-post.dto';
 
 @Injectable()
 export class PostService {
@@ -21,11 +28,11 @@ export class PostService {
 
     const createdPost = await this.postRepository.createPost(createPostDto, userId);
 
-    const newPostDetail = await this.postRepository.findPostById(createdPost.id);
+    const createdPostDetail = await this.postRepository.findPostById(createdPost.id);
 
-    if (!newPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
+    if (!createdPostDetail) throw new NotFoundException('생성된 게시글을 찾을 수 없습니다.');
 
-    return PostMapper.toDetailDto(newPostDetail);
+    return PostMapper.toDetailDto(createdPostDetail);
   }
 
   async findPosts(findPostsQuery: FindPostsQueryDto): Promise<ResponsePostListDto> {
@@ -42,10 +49,57 @@ export class PostService {
   }
 
   async findPostById(postId: number): Promise<ResponsePostDetailDto> {
+    const post = await this.findPostByIdOrThrow(postId);
+    return PostMapper.toDetailDto(post);
+  }
+
+  async updatePost(
+    updatePostDto: UpdatePostDto,
+    postId: number,
+    userId: number,
+  ): Promise<ResponsePostDetailDto> {
+    const existingPost = await this.findPostByIdOrThrow(postId);
+
+    await this.validatePost(updatePostDto, userId, existingPost.user.id);
+
+    const updatePostPayload = this.buildUpdatePostPayload(updatePostDto);
+
+    await this.postRepository.updatePost(postId, updatePostPayload);
+
+    return await this.findPostById(postId);
+  }
+
+  private buildUpdatePostPayload(updatePostDto: UpdatePostDto): UpdatePostPayloadDto {
+    const { categoryId, ...updatePostData } = updatePostDto;
+
+    const updatePostPayload: UpdatePostPayloadDto = {
+      ...updatePostData,
+    };
+    if (categoryId !== undefined) updatePostPayload.category = { id: categoryId };
+
+    return updatePostPayload;
+  }
+
+  private async validatePost(
+    updatePostDto: UpdatePostDto,
+    currentUserId: number,
+    authorId: number,
+  ): Promise<void> {
+    if (Object.keys(updatePostDto).length < 1)
+      throw new BadRequestException('수정할 값이 없습니다.');
+
+    if (authorId !== currentUserId)
+      throw new ForbiddenException('게시글을 수정할 권한이 없습니다.');
+
+    if (updatePostDto.categoryId !== undefined)
+      await this.postCategoryService.findPostCategoryById(updatePostDto.categoryId);
+  }
+
+  private async findPostByIdOrThrow(postId: number): Promise<Post> {
     const post = await this.postRepository.findPostById(postId);
 
     if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
-    return PostMapper.toDetailDto(post);
+    return post;
   }
 }

--- a/src/posts/types/post.type.ts
+++ b/src/posts/types/post.type.ts
@@ -1,0 +1,7 @@
+import { Post } from '../entities/post.entity';
+
+export type FindPostsResult = {
+  items: Post[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};

--- a/test/posts-create.e2e-spec.ts
+++ b/test/posts-create.e2e-spec.ts
@@ -1,0 +1,192 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { Post } from '../src/posts/entities/post.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Posts Create (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  function expectExceptionFilterErrorResponse(
+    response: Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
+
+  it('POST /posts 게시글 작성 성공', async () => {
+    const signupResponse = await signupUser('writer@example.com', 'writer');
+    const category = await createCategory('자유');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '학생식당 돈까스 맛있어요',
+        content: '오늘 점심에 먹었는데 소스가 정말 맛있었어요.',
+        categoryId: category.id,
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toEqual(expect.any(Number));
+    expect(response.body.title).toBe('학생식당 돈까스 맛있어요');
+    expect(response.body.content).toBe('오늘 점심에 먹었는데 소스가 정말 맛있었어요.');
+    expect(response.body.viewCount).toBe(0);
+    expect(response.body.commentCount).toBe(0);
+    expect(response.body.likeCount).toBe(0);
+    expect(response.body.isAnonymous).toBe(false);
+    expect(response.body.user).toEqual({
+      id: signupResponse.body.user.id,
+      nickname: 'writer',
+    });
+    expect(response.body.category).toEqual({
+      id: category.id,
+      name: '자유',
+    });
+    expect(response.body.createdAt).toEqual(expect.any(String));
+
+    const createdPost = await dataSource.getRepository(Post).findOne({
+      where: { id: response.body.id },
+      relations: {
+        user: true,
+        category: true,
+      },
+    });
+
+    expect(createdPost).toBeDefined();
+    expect(createdPost?.title).toBe('학생식당 돈까스 맛있어요');
+    expect(createdPost?.content).toBe('오늘 점심에 먹었는데 소스가 정말 맛있었어요.');
+    expect(createdPost?.user.id).toBe(signupResponse.body.user.id);
+    expect(createdPost?.category.id).toBe(category.id);
+  });
+
+  it('POST /posts 익명 게시글 작성 성공 시 user 는 null 이다', async () => {
+    const signupResponse = await signupUser('anonymous@example.com', 'anonymous-writer');
+    const category = await createCategory('정보');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '익명 후기',
+        content: '오늘 메뉴 꽤 괜찮았어요.',
+        categoryId: category.id,
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.isAnonymous).toBe(true);
+    expect(response.body.user).toBeNull();
+    expect(response.body.category).toEqual({
+      id: category.id,
+      name: '정보',
+    });
+  });
+
+  it('POST /posts 존재하지 않는 카테고리면 실패', async () => {
+    const signupResponse = await signupUser('missing-category@example.com', 'missing-category');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '없는 카테고리 글',
+        content: '이 요청은 실패해야 해요.',
+        categoryId: 999,
+        isAnonymous: false,
+      });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+  });
+
+  it('POST /posts 잘못된 요청값이면 실패', async () => {
+    const signupResponse = await signupUser('invalid-post@example.com', 'invalid-post');
+    const category = await createCategory('질문');
+
+    const response = await request(httpApp())
+      .post('/posts')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '   ',
+        content: '',
+        categoryId: 0,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining([
+        'title should not be empty',
+        'content should not be empty',
+        'categoryId must be a positive number',
+        'isAnonymous should not be empty',
+        'isAnonymous must be a boolean value',
+      ]),
+    );
+
+    const posts = await dataSource.getRepository(Post).find();
+    expect(posts).toHaveLength(0);
+    expect(category.id).toBeGreaterThan(0);
+  });
+
+  it('POST /posts 인증 없이 요청하면 실패', async () => {
+    const category = await createCategory('자유');
+
+    const response = await request(httpApp()).post('/posts').send({
+      title: '로그인 없이 작성',
+      content: '이 요청은 인증이 필요해요.',
+      categoryId: category.id,
+      isAnonymous: false,
+    });
+
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+  });
+});

--- a/test/posts-create.e2e-spec.ts
+++ b/test/posts-create.e2e-spec.ts
@@ -47,19 +47,6 @@ describe('Posts Create (e2e)', () => {
     return await dataSource.getRepository(PostCategory).save({ name });
   }
 
-  function expectExceptionFilterErrorResponse(
-    response: Response,
-    statusCode: number,
-    message: string | string[],
-  ): void {
-    expect(response.status).toBe(statusCode);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toEqual({
-      statusCode,
-      message,
-    });
-  }
-
   it('POST /posts 게시글 작성 성공', async () => {
     const signupResponse = await signupUser('writer@example.com', 'writer');
     const category = await createCategory('자유');
@@ -143,7 +130,12 @@ describe('Posts Create (e2e)', () => {
         isAnonymous: false,
       });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 400,
+      message: '존재하지 않는 카테고리입니다.',
+    });
   });
 
   it('POST /posts 잘못된 요청값이면 실패', async () => {
@@ -187,6 +179,11 @@ describe('Posts Create (e2e)', () => {
       isAnonymous: false,
     });
 
-    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
   });
 });

--- a/test/posts-read.e2e-spec.ts
+++ b/test/posts-read.e2e-spec.ts
@@ -63,19 +63,6 @@ describe('Posts Read (e2e)', () => {
     });
   }
 
-  function expectExceptionFilterErrorResponse(
-    response: Response,
-    statusCode: number,
-    message: string | string[],
-  ): void {
-    expect(response.status).toBe(statusCode);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toEqual({
-      statusCode,
-      message,
-    });
-  }
-
   it('GET /posts 전체 게시글 목록 조회 성공', async () => {
     const writerSignup = await signupUser('posts-list@example.com', 'list-writer');
     const writer = await dataSource.getRepository(User).findOneByOrFail({
@@ -225,7 +212,12 @@ describe('Posts Read (e2e)', () => {
       categoryId: 999,
     });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않은 카테고리입니다.',
+    });
   });
 
   it('GET /posts/:id 게시글 상세 조회 성공', async () => {
@@ -288,7 +280,12 @@ describe('Posts Read (e2e)', () => {
   it('GET /posts/:id 존재하지 않는 게시글이면 실패', async () => {
     const response = await request(httpApp()).get('/posts/999');
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
   });
 
   it('GET /posts/:id 잘못된 게시글 ID 면 실패', async () => {

--- a/test/posts-read.e2e-spec.ts
+++ b/test/posts-read.e2e-spec.ts
@@ -1,0 +1,301 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { Post } from '../src/posts/entities/post.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Posts Read (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPostFixture(params: {
+    title: string;
+    content: string;
+    user: User;
+    category: PostCategory;
+    isAnonymous?: boolean;
+  }): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: params.title,
+      content: params.content,
+      user: params.user,
+      category: params.category,
+      isAnonymous: params.isAnonymous ?? false,
+    });
+  }
+
+  function expectExceptionFilterErrorResponse(
+    response: Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
+
+  it('GET /posts 전체 게시글 목록 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-list@example.com', 'list-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+
+    const olderPost = await createPostFixture({
+      title: '첫 번째 글',
+      content: '첫 번째 내용',
+      user: writer,
+      category: freeCategory,
+    });
+    const latestPost = await createPostFixture({
+      title: '두 번째 글',
+      content: '두 번째 내용',
+      user: writer,
+      category: infoCategory,
+    });
+
+    const response = await request(httpApp()).get('/posts');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0]).toEqual({
+      id: latestPost.id,
+      title: '두 번째 글',
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: expect.any(String),
+      user: {
+        id: writer.id,
+        nickname: writer.nickname,
+      },
+    });
+    expect(response.body.items[1].id).toBe(olderPost.id);
+    expect(response.body.nextCursor).toBeNull();
+    expect(response.body.hasNext).toBe(false);
+    expect(response.body.items[0].content).toBeUndefined();
+  });
+
+  it('GET /posts categoryId 로 필터링 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-category@example.com', 'category-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+
+    await createPostFixture({
+      title: '자유 글',
+      content: '자유 내용',
+      user: writer,
+      category: freeCategory,
+    });
+    await createPostFixture({
+      title: '정보 글',
+      content: '정보 내용',
+      user: writer,
+      category: infoCategory,
+    });
+
+    const response = await request(httpApp()).get('/posts').query({
+      categoryId: infoCategory.id,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].title).toBe('정보 글');
+  });
+
+  it('GET /posts 커서 기반 페이징 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-cursor@example.com', 'cursor-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+
+    const firstPost = await createPostFixture({
+      title: '첫 글',
+      content: '첫 글 내용',
+      user: writer,
+      category,
+    });
+    const secondPost = await createPostFixture({
+      title: '둘째 글',
+      content: '둘째 글 내용',
+      user: writer,
+      category,
+    });
+    const thirdPost = await createPostFixture({
+      title: '셋째 글',
+      content: '셋째 글 내용',
+      user: writer,
+      category,
+    });
+
+    const firstPageResponse = await request(httpApp()).get('/posts').query({
+      limit: 2,
+    });
+
+    expect(firstPageResponse.status).toBe(200);
+    expect(firstPageResponse.body.items).toHaveLength(2);
+    expect(firstPageResponse.body.items[0].id).toBe(thirdPost.id);
+    expect(firstPageResponse.body.items[1].id).toBe(secondPost.id);
+    expect(firstPageResponse.body.nextCursor).toBe(secondPost.id);
+    expect(firstPageResponse.body.hasNext).toBe(true);
+
+    const nextPageResponse = await request(httpApp()).get('/posts').query({
+      cursor: firstPageResponse.body.nextCursor,
+      limit: 2,
+    });
+
+    expect(nextPageResponse.status).toBe(200);
+    expect(nextPageResponse.body.items).toHaveLength(1);
+    expect(nextPageResponse.body.items[0].id).toBe(firstPost.id);
+    expect(nextPageResponse.body.nextCursor).toBeNull();
+    expect(nextPageResponse.body.hasNext).toBe(false);
+  });
+
+  it('GET /posts 익명 게시글은 작성자 정보를 숨긴다', async () => {
+    const writerSignup = await signupUser('posts-anonymous@example.com', 'anonymous-reader');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+
+    await createPostFixture({
+      title: '익명 글',
+      content: '익명 내용',
+      user: writer,
+      category,
+      isAnonymous: true,
+    });
+
+    const response = await request(httpApp()).get('/posts');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].user).toBeNull();
+  });
+
+  it('GET /posts 존재하지 않는 카테고리면 실패', async () => {
+    const response = await request(httpApp()).get('/posts').query({
+      categoryId: 999,
+    });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+  });
+
+  it('GET /posts/:id 게시글 상세 조회 성공', async () => {
+    const writerSignup = await signupUser('posts-detail@example.com', 'detail-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '상세 글',
+      content: '상세 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      id: post.id,
+      title: '상세 글',
+      content: '상세 내용',
+      viewCount: 0,
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: expect.any(String),
+      user: {
+        id: writer.id,
+        nickname: writer.nickname,
+      },
+      category: {
+        id: category.id,
+        name: category.name,
+      },
+      isAnonymous: false,
+    });
+  });
+
+  it('GET /posts/:id 익명 게시글 상세 조회 시 작성자 정보를 숨긴다', async () => {
+    const writerSignup = await signupUser('posts-detail-anon@example.com', 'detail-anon');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('익명');
+    const post = await createPostFixture({
+      title: '익명 상세 글',
+      content: '익명 상세 내용',
+      user: writer,
+      category,
+      isAnonymous: true,
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toBeNull();
+    expect(response.body.isAnonymous).toBe(true);
+  });
+
+  it('GET /posts/:id 존재하지 않는 게시글이면 실패', async () => {
+    const response = await request(httpApp()).get('/posts/999');
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+  });
+
+  it('GET /posts/:id 잘못된 게시글 ID 면 실패', async () => {
+    const response = await request(httpApp()).get('/posts/abc');
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+  });
+});

--- a/test/posts-read.e2e-spec.ts
+++ b/test/posts-read.e2e-spec.ts
@@ -212,11 +212,11 @@ describe('Posts Read (e2e)', () => {
       categoryId: 999,
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
     expect(response.body.success).toBe(false);
     expect(response.body.error).toEqual({
-      statusCode: 404,
-      message: '존재하지 않은 카테고리입니다.',
+      statusCode: 400,
+      message: '존재하지 않는 카테고리입니다.',
     });
   });
 

--- a/test/posts-update.e2e-spec.ts
+++ b/test/posts-update.e2e-spec.ts
@@ -1,0 +1,296 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { Post } from '../src/posts/entities/post.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Posts Update (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPostFixture(params: {
+    title: string;
+    content: string;
+    user: User;
+    category: PostCategory;
+    isAnonymous?: boolean;
+  }): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: params.title,
+      content: params.content,
+      user: params.user,
+      category: params.category,
+      isAnonymous: params.isAnonymous ?? false,
+    });
+  }
+
+  function expectExceptionFilterErrorResponse(
+    response: Response,
+    statusCode: number,
+    message: string | string[],
+  ): void {
+    expect(response.status).toBe(statusCode);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode,
+      message,
+    });
+  }
+
+  it('PATCH /posts/:id 작성자가 게시글을 수정한다', async () => {
+    const signupResponse = await signupUser('post-update@example.com', 'post-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+    const post = await createPostFixture({
+      title: '수정 전 제목',
+      content: '수정 전 내용',
+      user: writer,
+      category: freeCategory,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '수정 후 제목',
+        content: '수정 후 내용',
+        categoryId: infoCategory.id,
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(post.id);
+    expect(response.body.title).toBe('수정 후 제목');
+    expect(response.body.content).toBe('수정 후 내용');
+    expect(response.body.isAnonymous).toBe(true);
+    expect(response.body.user).toBeNull();
+    expect(response.body.category).toEqual({
+      id: infoCategory.id,
+      name: infoCategory.name,
+    });
+
+    const updatedPost = await dataSource.getRepository(Post).findOne({
+      where: { id: post.id },
+      relations: {
+        user: true,
+        category: true,
+      },
+    });
+
+    expect(updatedPost?.title).toBe('수정 후 제목');
+    expect(updatedPost?.content).toBe('수정 후 내용');
+    expect(updatedPost?.isAnonymous).toBe(true);
+    expect(updatedPost?.category.id).toBe(infoCategory.id);
+  });
+
+  it('PATCH /posts/:id 카테고리만 수정할 수 있다', async () => {
+    const signupResponse = await signupUser('post-update-category@example.com', 'category-writer');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const freeCategory = await createCategory('자유');
+    const infoCategory = await createCategory('정보');
+    const post = await createPostFixture({
+      title: '카테고리 변경 전 제목',
+      content: '카테고리 변경 전 내용',
+      user: writer,
+      category: freeCategory,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        categoryId: infoCategory.id,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.title).toBe('카테고리 변경 전 제목');
+    expect(response.body.content).toBe('카테고리 변경 전 내용');
+    expect(response.body.category).toEqual({
+      id: infoCategory.id,
+      name: infoCategory.name,
+    });
+
+    const updatedPost = await dataSource.getRepository(Post).findOne({
+      where: { id: post.id },
+      relations: {
+        category: true,
+      },
+    });
+
+    expect(updatedPost?.category.id).toBe(infoCategory.id);
+  });
+
+  it('PATCH /posts/:id 작성자가 아니면 수정에 실패한다', async () => {
+    const writerSignup = await signupUser('post-owner@example.com', 'post-owner');
+    const otherSignup = await signupUser('post-other@example.com', 'post-other');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: writerSignup.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '원본 제목',
+      content: '원본 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${otherSignup.body.accessToken}`)
+      .send({
+        title: '권한 없는 수정',
+      });
+
+    expectExceptionFilterErrorResponse(response, 403, '게시글을 수정할 권한이 없습니다.');
+  });
+
+  it('PATCH /posts/:id 잘못된 수정값이면 실패한다', async () => {
+    const signupResponse = await signupUser('post-invalid@example.com', 'post-invalid');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '원본 제목',
+      content: '원본 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '   ',
+        categoryId: 0,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining(['title should not be empty', 'categoryId must be a positive number']),
+    );
+  });
+
+  it('PATCH /posts/:id 수정할 값이 없으면 실패한다', async () => {
+    const signupResponse = await signupUser('post-empty@example.com', 'post-empty');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '원본 제목',
+      content: '원본 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({});
+
+    expectExceptionFilterErrorResponse(response, 400, '수정할 값이 없습니다.');
+  });
+
+  it('PATCH /posts/:id 존재하지 않는 카테고리로 수정하면 실패한다', async () => {
+    const signupResponse = await signupUser('post-missing-category@example.com', 'missing-category');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '원본 제목',
+      content: '원본 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        categoryId: 999,
+      });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+  });
+
+  it('PATCH /posts/:id 존재하지 않는 게시글을 수정하면 실패한다', async () => {
+    const signupResponse = await signupUser('post-not-found@example.com', 'not-found');
+
+    const response = await request(httpApp())
+      .patch('/posts/999')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        title: '없는 게시글 수정',
+      });
+
+    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+  });
+
+  it('PATCH /posts/:id 인증 없이 수정하면 실패한다', async () => {
+    const signupResponse = await signupUser('post-auth-owner@example.com', 'auth-owner');
+    const writer = await dataSource.getRepository(User).findOneByOrFail({
+      id: signupResponse.body.user.id,
+    });
+    const category = await createCategory('자유');
+    const post = await createPostFixture({
+      title: '원본 제목',
+      content: '원본 내용',
+      user: writer,
+      category,
+    });
+
+    const response = await request(httpApp()).patch(`/posts/${post.id}`).send({
+      title: '로그인 없이 수정',
+    });
+
+    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+  });
+});

--- a/test/posts-update.e2e-spec.ts
+++ b/test/posts-update.e2e-spec.ts
@@ -63,19 +63,6 @@ describe('Posts Update (e2e)', () => {
     });
   }
 
-  function expectExceptionFilterErrorResponse(
-    response: Response,
-    statusCode: number,
-    message: string | string[],
-  ): void {
-    expect(response.status).toBe(statusCode);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toEqual({
-      statusCode,
-      message,
-    });
-  }
-
   it('PATCH /posts/:id 작성자가 게시글을 수정한다', async () => {
     const signupResponse = await signupUser('post-update@example.com', 'post-writer');
     const writer = await dataSource.getRepository(User).findOneByOrFail({
@@ -185,7 +172,12 @@ describe('Posts Update (e2e)', () => {
         title: '권한 없는 수정',
       });
 
-    expectExceptionFilterErrorResponse(response, 403, '게시글을 수정할 권한이 없습니다.');
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 403,
+      message: '게시글을 수정할 권한이 없습니다.',
+    });
   });
 
   it('PATCH /posts/:id 잘못된 수정값이면 실패한다', async () => {
@@ -235,11 +227,19 @@ describe('Posts Update (e2e)', () => {
       .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
       .send({});
 
-    expectExceptionFilterErrorResponse(response, 400, '수정할 값이 없습니다.');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 400,
+      message: '수정할 값이 없습니다.',
+    });
   });
 
   it('PATCH /posts/:id 존재하지 않는 카테고리로 수정하면 실패한다', async () => {
-    const signupResponse = await signupUser('post-missing-category@example.com', 'missing-category');
+    const signupResponse = await signupUser(
+      'post-missing-category@example.com',
+      'missing-category',
+    );
     const writer = await dataSource.getRepository(User).findOneByOrFail({
       id: signupResponse.body.user.id,
     });
@@ -258,7 +258,12 @@ describe('Posts Update (e2e)', () => {
         categoryId: 999,
       });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않은 카테고리입니다.');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 400,
+      message: '존재하지 않는 카테고리입니다.',
+    });
   });
 
   it('PATCH /posts/:id 존재하지 않는 게시글을 수정하면 실패한다', async () => {
@@ -271,7 +276,12 @@ describe('Posts Update (e2e)', () => {
         title: '없는 게시글 수정',
       });
 
-    expectExceptionFilterErrorResponse(response, 404, '존재하지 않는 게시글입니다.');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
   });
 
   it('PATCH /posts/:id 인증 없이 수정하면 실패한다', async () => {
@@ -291,6 +301,11 @@ describe('Posts Update (e2e)', () => {
       title: '로그인 없이 수정',
     });
 
-    expectExceptionFilterErrorResponse(response, 401, 'Unauthorized');
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
   });
 });

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -21,6 +21,7 @@ import { FriendModule } from '../src/friends/friends.module';
 import { MealMenuReaction } from '../src/meal-menus/entities/meal-menu-reaction.entity';
 import { MealMenu } from '../src/meal-menus/entities/meal-menu.entity';
 import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { PostModule } from '../src/posts/posts.module';
 import { PostLike } from '../src/posts/entities/post-like.entity';
 import { Post } from '../src/posts/entities/post.entity';
 import { RoomMember } from '../src/rooms/entities/room-member.entity';
@@ -104,6 +105,7 @@ export async function createAuthUserTestApp(): Promise<INestApplication> {
       }),
       UserModule,
       AuthModule,
+      PostModule,
       RoomModule,
       FriendModule,
     ],


### PR DESCRIPTION
## 연관된 이슈

- #119 

## 📝 작업 내용

- [x] PATCH /posts/:id 게시판 수정 API 구현
- [x] PostController에 게시글 수정 엔드포인트 추가
- [x] 게시글 수정 Swagger 문서화 추가
- [x] 게시글 존재 여부 검증 추가
- [x] 로그인한 사용자 기반 게시글 수정 적용
- [x] 자기 자신이 생성한 게시글만 수정하도록 검증 추가
- [x] 게시글 수정 단위 테스트 추가
- [x] 게시글 수정 e2e 테스트 추가