### PR TITLE
createRelationQuery 누락 보완

### DIFF
--- a/src/friends/friends.repository.ts
+++ b/src/friends/friends.repository.ts
@@ -73,6 +73,19 @@ export class FriendRepository {
     await this.friendRepository.softDelete(friendId);
   }
 
+  private createRelationQuery(options?: { withDeleted?: boolean }): SelectQueryBuilder<Friend> {
+    const queryBuilder = this.friendRepository
+      .createQueryBuilder('friend')
+      .leftJoinAndSelect('friend.requester', 'requester')
+      .leftJoinAndSelect('friend.receiver', 'receiver');
+
+    if (options?.withDeleted) {
+      queryBuilder.withDeleted();
+    }
+
+    return queryBuilder;
+  }
+
   private async createRequestAndReload(
     repository: Repository<Friend>,
     requesterId: number,


### PR DESCRIPTION
## 연관된 이슈

- #129

## 📝 작업 내용

- [x] FriendRepository 내부에서 createRelationQuery()가 호출되고 있으나 정의가 누락되어 있는 상태를 확인합니다.
- [x] friend를 기준 alias로 사용하고 requester, receiver를 함께 조회하는 공통 QueryBuilder 메서드를 추가합니다.
- [x] withDeleted 옵션을 통해 soft delete 된 데이터까지 포함하여 조회할 수 있도록 확장 가능한 형태로 구성합니다.
- [x] findActiveRelationsBetweenUsers, findAcceptedRelationsForUser, findRestorableRequest에서 기존 호출부 수정 없이 그대로 사용할 수 있도록 호환성을 유지합니다.