### PR TITLE
FindPostsQueryDto 최소값 상수로 통일

### DIFF
--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -5,5 +5,7 @@ export const POST_CONSTANTS = {
 
 export const PAGINATION_CONSTANTS = {
   MAX_LIMIT: 200,
+  MIN_LIMIT: 1,
   DEFAULT_LIMIT: 20,
+  MIN_CURSOR_ID: 1,
 };

--- a/src/posts/dtos/find-posts-query.dto.ts
+++ b/src/posts/dtos/find-posts-query.dto.ts
@@ -7,13 +7,16 @@ export class FindPostsQueryDto {
   @ApiPropertyOptional({ minimum: 1 })
   @IsOptional()
   @Type(() => Number)
-  @Min(1)
+  @Min(PAGINATION_CONSTANTS.MIN_CURSOR_ID)
   cursor?: number;
 
-  @ApiPropertyOptional({ minimum: 1, maximum: PAGINATION_CONSTANTS.MAX_LIMIT })
+  @ApiPropertyOptional({
+    minimum: PAGINATION_CONSTANTS.MIN_LIMIT,
+    maximum: PAGINATION_CONSTANTS.MAX_LIMIT,
+  })
   @IsOptional()
   @Type(() => Number)
-  @Min(1)
+  @Min(PAGINATION_CONSTANTS.MIN_LIMIT)
   @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
   limit?: number;
 


### PR DESCRIPTION
## 연관된 이슈

- #121 

## 📝 작업 내용

- [x] FindPostsQueryDto의 cursor 최소값을 상수로 변경
- [x] FindPostsQueryDto의 limit 최소값을 상수로 변경
