### PR TITLE
PostLikeService 좋아요 함수 네이밍 수정

### DIFF
--- a/src/posts/constants/post.constant.ts
+++ b/src/posts/constants/post.constant.ts
@@ -5,5 +5,7 @@ export const POST_CONSTANTS = {
 
 export const PAGINATION_CONSTANTS = {
   MAX_LIMIT: 200,
+  MIN_LIMIT: 1,
   DEFAULT_LIMIT: 20,
+  MIN_CURSOR_ID: 1,
 };

--- a/src/posts/dtos/find-posts-query.dto.ts
+++ b/src/posts/dtos/find-posts-query.dto.ts
@@ -7,13 +7,16 @@ export class FindPostsQueryDto {
   @ApiPropertyOptional({ minimum: 1 })
   @IsOptional()
   @Type(() => Number)
-  @Min(1)
+  @Min(PAGINATION_CONSTANTS.MIN_CURSOR_ID)
   cursor?: number;
 
-  @ApiPropertyOptional({ minimum: 1, maximum: PAGINATION_CONSTANTS.MAX_LIMIT })
+  @ApiPropertyOptional({
+    minimum: PAGINATION_CONSTANTS.MIN_LIMIT,
+    maximum: PAGINATION_CONSTANTS.MAX_LIMIT,
+  })
   @IsOptional()
   @Type(() => Number)
-  @Min(1)
+  @Min(PAGINATION_CONSTANTS.MIN_LIMIT)
   @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
   limit?: number;
 

--- a/src/posts/post-like.service.ts
+++ b/src/posts/post-like.service.ts
@@ -6,11 +6,11 @@ import { EntityManager } from 'typeorm';
 export class PostLikeService {
   constructor(private readonly postLikeRepository: PostLikeRepository) {}
 
-  async saveLike(postId: number, userId: number, manager: EntityManager) {
+  async likePost(postId: number, userId: number, manager: EntityManager) {
     return await this.postLikeRepository.saveLike(postId, userId, manager);
   }
 
-  async deleteLike(postId: number, userId: number, manager: EntityManager) {
+  async unlikePost(postId: number, userId: number, manager: EntityManager) {
     return await this.postLikeRepository.deleteLike(postId, userId, manager);
   }
 

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -57,8 +57,8 @@ const mockPostCategoryService = {
 };
 
 const mockPostLikeService = {
-  saveLike: jest.fn(),
-  deleteLike: jest.fn(),
+  likePost: jest.fn(),
+  unlikePost: jest.fn(),
   findPostLikeById: jest.fn(),
 };
 
@@ -339,7 +339,7 @@ describe('PostService', () => {
         likeCount: 1,
       };
       mockPostLikeService.findPostLikeById.mockResolvedValue(null);
-      mockPostLikeService.saveLike.mockResolvedValue(undefined);
+      mockPostLikeService.likePost.mockResolvedValue(undefined);
       mockPostRepository.increasePostLikeCount.mockResolvedValue({ affected: 1 });
       mockPostRepository.findPostById
         .mockResolvedValueOnce(mockPostEntity)
@@ -351,7 +351,7 @@ describe('PostService', () => {
       expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(2, 3, mockManager);
       expect(mockPostLikeService.findPostLikeById).toHaveBeenCalledWith(3, 8);
       expect(mockDataSource.transaction).toHaveBeenCalled();
-      expect(mockPostLikeService.saveLike).toHaveBeenCalledWith(3, 8, mockManager);
+      expect(mockPostLikeService.likePost).toHaveBeenCalledWith(3, 8, mockManager);
       expect(mockPostRepository.increasePostLikeCount).toHaveBeenCalledWith(3, mockManager);
     });
 
@@ -379,7 +379,7 @@ describe('PostService', () => {
       mockPostLikeService.findPostLikeById.mockResolvedValue({
         id: 1,
       });
-      mockPostLikeService.deleteLike.mockResolvedValue({ affected: 1 });
+      mockPostLikeService.unlikePost.mockResolvedValue({ affected: 1 });
       mockPostRepository.decreasePostLikeCount.mockResolvedValue({ affected: 1 });
 
       await expect(postService.deletePostLike(3, 8)).resolves.toEqual(mockPostEntity);
@@ -388,7 +388,7 @@ describe('PostService', () => {
       expect(mockPostRepository.findPostById).toHaveBeenNthCalledWith(2, 3, mockManager);
       expect(mockPostLikeService.findPostLikeById).toHaveBeenCalledWith(3, 8);
       expect(mockDataSource.transaction).toHaveBeenCalled();
-      expect(mockPostLikeService.deleteLike).toHaveBeenCalledWith(3, 8, mockManager);
+      expect(mockPostLikeService.unlikePost).toHaveBeenCalledWith(3, 8, mockManager);
       expect(mockPostRepository.decreasePostLikeCount).toHaveBeenCalledWith(3, mockManager);
     });
 
@@ -406,7 +406,7 @@ describe('PostService', () => {
       mockPostLikeService.findPostLikeById.mockResolvedValue({
         id: 1,
       });
-      mockPostLikeService.deleteLike.mockResolvedValue({ affected: 0 });
+      mockPostLikeService.unlikePost.mockResolvedValue({ affected: 0 });
 
       await expect(postService.deletePostLike(3, 8)).rejects.toThrow(NotFoundException);
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -97,7 +97,7 @@ export class PostService {
     if (existingPostLike) throw new BadRequestException('이미 좋아요한 게시글입니다.');
 
     return await this.dataSource.transaction(async (manager) => {
-      await this.postLikeService.saveLike(postId, userId, manager);
+      await this.postLikeService.likePost(postId, userId, manager);
 
       await this.postRepository.increasePostLikeCount(postId, manager);
 
@@ -112,7 +112,7 @@ export class PostService {
     if (!existingPostLike) throw new NotFoundException('좋아요하지 않은 게시글입니다.');
 
     return await this.dataSource.transaction(async (manager) => {
-      const deleteResult = await this.postLikeService.deleteLike(postId, userId, manager);
+      const deleteResult = await this.postLikeService.unlikePost(postId, userId, manager);
 
       if (!deleteResult.affected) throw new NotFoundException('좋아요하지 않은 게시글입니다.');
 


### PR DESCRIPTION
## 연관된 이슈

- #123 

## 📝 작업 내용
- [x] 서비스 계층에서의 함수 네이밍을 데이터 처리 관점에서 행동 중심으로 수정
- [x] PostLikeService의 좋아요 함수 saveLike -> likePost로 수정
- [x] PostLikeService의 좋아요 함수 deleteLike -> unlikePost로 수정
