### PR TITLE
댓글 작성 API 구현

### DIFF
--- a/migrations/1775977285817-AddIsAnonymousInComment.ts
+++ b/migrations/1775977285817-AddIsAnonymousInComment.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsAnonymousInComment1775977285817 implements MigrationInterface {
+    name = 'AddIsAnonymousInComment1775977285817'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" ADD "is_anonymous" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" DROP COLUMN "is_anonymous"`);
+    }
+
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Comment } from './entities/comment.entity';
 import { CommentLike } from './entities/comment-like.entity';
+import { CommentService } from './comments.service';
+import { CommentRepository } from './comments.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment, CommentLike])],
   controllers: [],
-  providers: [],
+  providers: [CommentService, CommentRepository],
 })
 export class CommentModule {}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -4,10 +4,13 @@ import { Comment } from './entities/comment.entity';
 import { CommentLike } from './entities/comment-like.entity';
 import { CommentService } from './comments.service';
 import { CommentRepository } from './comments.repository';
+import { Post } from 'src/posts/entities/post.entity';
+import { PostRepository } from 'src/posts/posts.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment, CommentLike])],
+  imports: [TypeOrmModule.forFeature([Comment, CommentLike, Post])],
   controllers: [],
-  providers: [CommentService, CommentRepository],
+  providers: [CommentService, CommentRepository, PostRepository],
+  exports: [CommentService],
 })
 export class CommentModule {}

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -1,0 +1,73 @@
+import { Repository } from 'typeorm';
+import { CommentRepository } from './comments.repository';
+import { Comment } from './entities/comment.entity';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+
+describe('CommentRepository', () => {
+  let commentRepository: CommentRepository;
+  let commentOrmRepository: Pick<Repository<Comment>, 'findOne'>;
+  const manager = {
+    save: jest.fn(),
+  };
+
+  beforeEach(() => {
+    commentOrmRepository = {
+      findOne: jest.fn(),
+    };
+
+    commentRepository = new CommentRepository(commentOrmRepository as Repository<Comment>);
+  });
+
+  describe('createComment', () => {
+    it('createCommentDTO, postId, userId로 manager.save를 호출', async () => {
+      const createCommentDto: CreateCommentDto = {
+        content: '저도 같은 생각입니다.',
+        isAnonymous: false,
+      };
+      const savedComment = {
+        id: 11,
+        ...createCommentDto,
+      };
+
+      (manager.save as jest.Mock).mockResolvedValue(savedComment);
+
+      const result = await commentRepository.createComment(
+        createCommentDto,
+        3,
+        7,
+        manager as never,
+      );
+
+      expect(result).toEqual(savedComment);
+      expect(manager.save).toHaveBeenCalledWith(Comment, {
+        content: createCommentDto.content,
+        isAnonymous: createCommentDto.isAnonymous,
+        post: { id: 3 },
+        user: { id: 7 },
+      });
+    });
+  });
+
+  describe('findCommentById', () => {
+    it('commentId로 findOne을 호출', async () => {
+      const comment = {
+        id: 11,
+        content: '댓글',
+      };
+
+      (commentOrmRepository.findOne as jest.Mock).mockResolvedValue(comment);
+
+      const result = await commentRepository.findCommentById(11);
+
+      expect(result).toEqual(comment);
+      expect(commentOrmRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: 11,
+        },
+        relations: {
+          user: true,
+        },
+      });
+    });
+  });
+});

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+import { Comment } from './entities/comment.entity';
 
 @Injectable()
 export class CommentRepository {
@@ -8,4 +10,24 @@ export class CommentRepository {
     @InjectRepository(Comment)
     private readonly commentRepository: Repository<Comment>,
   ) {}
+
+  async createComment(
+    createCommentDto: CreateCommentDto,
+    postId: number,
+    userId: number,
+    manager: EntityManager,
+  ) {
+    return await manager.save(Comment, {
+      ...createCommentDto,
+      post: { id: postId },
+      user: { id: userId },
+    });
+  }
+
+  async findCommentById(commentId: number): Promise<Comment | null> {
+    return await this.commentRepository.findOne({
+      where: { id: commentId },
+      relations: { user: true },
+    });
+  }
 }

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CommentRepository {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) {}
+}

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 import { CommentService } from './comments.service';
 import { CommentRepository } from './comments.repository';
@@ -115,14 +115,14 @@ describe('CommentService', () => {
       expect(mockCommentRepository.createComment).not.toHaveBeenCalled();
     });
 
-    it('생성 후 댓글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+    it('생성 후 댓글을 다시 조회하지 못하면 InternalServerErrorException을 던진다', async () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
       mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
       mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
       mockCommentRepository.findCommentById.mockResolvedValue(null);
 
       await expect(commentService.createComment(createCommentDto, 3, 7)).rejects.toThrow(
-        NotFoundException,
+        InternalServerErrorException,
       );
     });
   });
@@ -136,10 +136,10 @@ describe('CommentService', () => {
       expect(result).toEqual(mockCommentEntity);
     });
 
-    it('존재하지 않는 댓글이면 NotFoundException을 던진다', async () => {
+    it('존재하지 않는 댓글이면 null을 반환한다', async () => {
       mockCommentRepository.findCommentById.mockResolvedValue(null);
 
-      await expect(commentService.findCommentById(999)).rejects.toThrow(NotFoundException);
+      await expect(commentService.findCommentById(999)).resolves.toBeNull();
     });
   });
 });

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+import { CommentService } from './comments.service';
+import { CommentRepository } from './comments.repository';
+import { PostRepository } from 'src/posts/posts.repository';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+
+const createCommentDto: CreateCommentDto = {
+  content: '저도 같은 생각입니다.',
+  isAnonymous: false,
+};
+
+const mockPost = {
+  id: 3,
+  title: '댓글이 달릴 게시글',
+};
+
+const mockCreatedComment = {
+  id: 11,
+};
+
+const mockCommentEntity = {
+  id: 11,
+  content: createCommentDto.content,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-16T00:00:00.000Z',
+  user: {
+    id: 7,
+    nickname: 'commenter',
+  },
+};
+
+const mockCommentRepository = {
+  createComment: jest.fn(),
+  findCommentById: jest.fn(),
+};
+
+const mockPostRepository = {
+  findPostById: jest.fn(),
+  increaseCommentCount: jest.fn(),
+};
+
+const mockManager = {} as EntityManager;
+
+const mockDataSource = {
+  transaction: jest.fn(),
+};
+
+describe('CommentService', () => {
+  let commentService: CommentService;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+
+    mockDataSource.transaction.mockImplementation(
+      async <T>(callback: (manager: EntityManager) => Promise<T>): Promise<T> => {
+        return callback(mockManager);
+      },
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: CommentRepository,
+          useValue: mockCommentRepository,
+        },
+        {
+          provide: PostRepository,
+          useValue: mockPostRepository,
+        },
+      ],
+    }).compile();
+
+    commentService = module.get<CommentService>(CommentService);
+  });
+
+  describe('createComment', () => {
+    it('게시글을 검증하고 댓글 생성 후 상세 정보를 반환한다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
+      mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
+      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+
+      const result = await commentService.createComment(createCommentDto, 3, 7);
+
+      expect(result).toEqual(mockCommentEntity);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockCommentRepository.createComment).toHaveBeenCalledWith(
+        createCommentDto,
+        3,
+        7,
+        mockManager,
+      );
+      expect(mockPostRepository.increaseCommentCount).toHaveBeenCalledWith(3, mockManager);
+      expect(mockCommentRepository.findCommentById).toHaveBeenCalledWith(11);
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(commentService.createComment(createCommentDto, 999, 7)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+      expect(mockCommentRepository.createComment).not.toHaveBeenCalled();
+    });
+
+    it('생성 후 댓글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
+      mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
+      mockCommentRepository.findCommentById.mockResolvedValue(null);
+
+      await expect(commentService.createComment(createCommentDto, 3, 7)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findCommentById', () => {
+    it('댓글 상세 정보를 반환한다', async () => {
+      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+
+      const result = await commentService.findCommentById(11);
+
+      expect(result).toEqual(mockCommentEntity);
+    });
+
+    it('존재하지 않는 댓글이면 NotFoundException을 던진다', async () => {
+      mockCommentRepository.findCommentById.mockResolvedValue(null);
+
+      await expect(commentService.findCommentById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { CommentRepository } from './comments.repository';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+import { PostService } from 'src/posts/posts.service';
+
+@Injectable()
+export class CommentService {
+  constructor(
+    private readonly commentRepository: CommentRepository,
+    private readonly postService: PostService,
+  ) {}
+
+  async createComment(
+    createCommentDto: CreateCommentDto,
+    postId: number,
+    userId: number,
+  ): Promise<Comment> {
+    const post = await this.postService.findPostByIdOrThrow(postId);
+
+    // 댓글 저장
+
+    // 저장된 댓글 반환
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { CommentRepository } from './comments.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { Comment } from './entities/comment.entity';
@@ -34,13 +34,13 @@ export class CommentService {
       return createdComment.id;
     });
 
-    return this.findCommentById(createdCommentId);
+    const foundComment = await this.findCommentById(createdCommentId);
+    if (!foundComment) throw new InternalServerErrorException('생성된 댓글 조회에 실패했습니다.');
+
+    return foundComment;
   }
 
-  async findCommentById(commentId: number): Promise<Comment> {
-    const comment = await this.commentRepository.findCommentById(commentId);
-    if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
-
-    return comment;
+  async findCommentById(commentId: number): Promise<Comment | null> {
+    return await this.commentRepository.findCommentById(commentId);
   }
 }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CommentRepository } from './comments.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
-import { PostService } from 'src/posts/posts.service';
+import { Comment } from './entities/comment.entity';
+import { PostRepository } from 'src/posts/posts.repository';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class CommentService {
   constructor(
     private readonly commentRepository: CommentRepository,
-    private readonly postService: PostService,
+    private readonly postRepository: PostRepository,
+    private readonly dataSource: DataSource,
   ) {}
 
   async createComment(
@@ -15,10 +18,29 @@ export class CommentService {
     postId: number,
     userId: number,
   ): Promise<Comment> {
-    const post = await this.postService.findPostByIdOrThrow(postId);
+    const post = await this.postRepository.findPostById(postId);
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
-    // 댓글 저장
+    const createdCommentId = await this.dataSource.transaction(async (manager) => {
+      const createdComment = await this.commentRepository.createComment(
+        createCommentDto,
+        postId,
+        userId,
+        manager,
+      );
 
-    // 저장된 댓글 반환
+      await this.postRepository.increaseCommentCount(postId, manager);
+
+      return createdComment.id;
+    });
+
+    return this.findCommentById(createdCommentId);
+  }
+
+  async findCommentById(commentId: number): Promise<Comment> {
+    const comment = await this.commentRepository.findCommentById(commentId);
+    if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
+
+    return comment;
   }
 }

--- a/src/comments/constants/comment.constant.ts
+++ b/src/comments/constants/comment.constant.ts
@@ -1,0 +1,3 @@
+export const COMMENT_CONSTANTS = {
+  MAX_CONTENTS: 500,
+};

--- a/src/comments/dtos/create-comment.dto.ts
+++ b/src/comments/dtos/create-comment.dto.ts
@@ -1,0 +1,20 @@
+import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { COMMENT_CONSTANTS } from '../constants/comment.constant';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCommentDto {
+  @ApiProperty({
+    example: `맞아요. 저도 동의합니다.`,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(COMMENT_CONSTANTS.MAX_CONTENTS)
+  content: string;
+
+  @ApiProperty({
+    example: false,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isAnonymous: boolean;
+}

--- a/src/comments/dtos/response-comment.dto.ts
+++ b/src/comments/dtos/response-comment.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResponseCommentDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  user: CommentAuthorDto | null;
+}
+
+export class CommentAuthorDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  nickname: string;
+}

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -20,6 +20,12 @@ export class Comment extends BaseTableEntity {
   })
   likeCount: number;
 
+  @Column({
+    default: false,
+    name: 'is_anonymous',
+  })
+  isAnonymous: boolean;
+
   @OneToMany(() => CommentLike, (commentLike) => commentLike.comment)
   commentLikes: CommentLike[];
 

--- a/src/comments/mappers/comment.mapper.ts
+++ b/src/comments/mappers/comment.mapper.ts
@@ -1,0 +1,22 @@
+import { User } from 'src/users/entities/user.entity';
+import { CommentAuthorDto, ResponseCommentDto } from '../dtos/response-comment.dto';
+import { Comment } from '../entities/comment.entity';
+
+export class CommentMapper {
+  static toCommentDetailDto(comment: Comment): ResponseCommentDto {
+    return {
+      id: comment.id,
+      content: comment.content,
+      createdAt: comment.createdAt,
+      likeCount: comment.likeCount,
+      user: comment.isAnonymous ? null : this.toAuthorDto(comment.user),
+    };
+  }
+
+  static toAuthorDto(user: User): CommentAuthorDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,3 +1,4 @@
+import { CommentService } from './../comments/comments.service';
 import {
   Body,
   Controller,
@@ -38,12 +39,16 @@ import {
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 import { UpdatePostDto } from './dtos/update-post.dto';
 import { ResponsePostLikeDto } from './dtos/response-post-like.dto';
+import { CreateCommentDto } from 'src/comments/dtos/create-comment.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
 @Controller('posts')
 export class PostController {
-  constructor(private readonly postService: PostService) {}
+  constructor(
+    private readonly postService: PostService,
+    private readonly commentService: CommentService,
+  ) {}
 
   @Authenticated()
   @Post()
@@ -152,5 +157,16 @@ export class PostController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostLikeDto> {
     return await this.postService.deletePostLike(postId, user.userId);
+  }
+
+  // 댓글 엔드포인트
+  @Post(':id/comments')
+  @Authenticated()
+  async createComment(
+    @Body() createCommentDto: CreateCommentDto,
+    @Param('id', ParseIntPipe) postId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return await this.commentService.createComment(createCommentDto, postId, user.userId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -42,6 +42,8 @@ import { ResponsePostLikeDto } from './dtos/response-post-like.dto';
 import { CreateCommentDto } from 'src/comments/dtos/create-comment.dto';
 import { PostMapper } from './mappers/post-mapper';
 import { PostLikeMapper } from './mappers/post-like.mapper';
+import { CommentMapper } from 'src/comments/mappers/comment.mapper';
+import { ResponseCommentDto } from 'src/comments/dtos/response-comment.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -185,11 +187,22 @@ export class PostController {
   // 댓글 엔드포인트
   @Post(':id/comments')
   @Authenticated()
+  @ApiOperation({ summary: '게시글 댓글 작성' })
+  @ApiCreatedResponse({ type: ResponseCommentDto, description: '댓글 작성 성공' })
+  @ApiNotFoundResponse({
+    description: '존재하지 않는 게시글에 댓글을 작성하려는 경우',
+  })
   async createComment(
     @Body() createCommentDto: CreateCommentDto,
     @Param('id', ParseIntPipe) postId: number,
     @CurrentUser() user: AuthenticatedUser,
-  ) {
-    return await this.commentService.createComment(createCommentDto, postId, user.userId);
+  ): Promise<ResponseCommentDto> {
+    const createdComment = await this.commentService.createComment(
+      createCommentDto,
+      postId,
+      user.userId,
+    );
+
+    return CommentMapper.toCommentDetailDto(createdComment);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -8,10 +8,12 @@ import { PostRepository } from './posts.repository';
 import { PostCategoryModule } from 'src/post-categories/post-categories.module';
 import { PostLikeService } from './post-like.service';
 import { PostLikeRepository } from './post-like.repository';
+import { CommentModule } from 'src/comments/comments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule],
+  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule, CommentModule],
   controllers: [PostController],
   providers: [PostService, PostRepository, PostLikeService, PostLikeRepository],
+  exports: [PostService, PostRepository],
 })
 export class PostModule {}

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -83,4 +83,8 @@ export class PostRepository {
   async increaseViewCount(postId: number): Promise<UpdateResult> {
     return await this.postRepository.increment({ id: postId }, 'viewCount', 1);
   }
+
+  async increaseCommentCount(postId: number, manager: EntityManager): Promise<UpdateResult> {
+    return await manager.increment(Post, { id: postId }, 'commentCount', 1);
+  }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -131,24 +131,6 @@ export class PostService {
     return existingPost.viewCount + 1;
   }
 
-  private validatePostAuthor(currentUserId: number, authorId: number): void {
-    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
-  }
-
-  async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
-    const post = await this.postRepository.findPostById(postId, manager);
-
-    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
-
-    return post;
-  }
-
-  private async increasePostViewCount(postId: number): Promise<void> {
-    await this.findPostByIdOrThrow(postId);
-
-    await this.postRepository.increaseViewCount(postId);
-  }
-
   private buildUpdatePostPayload(updatePostDto: UpdatePostDto): UpdatePostPayloadDto {
     const { categoryId, ...updatePostData } = updatePostDto;
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -135,6 +135,24 @@ export class PostService {
     return PostLikeMapper.toPostLikeDto(post, false);
   }
 
+  private validatePostAuthor(currentUserId: number, authorId: number): void {
+    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
+  }
+
+  async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
+    const post = await this.postRepository.findPostById(postId, manager);
+
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    return post;
+  }
+
+  private async increasePostViewCount(postId: number): Promise<void> {
+    await this.findPostByIdOrThrow(postId);
+
+    await this.postRepository.increaseViewCount(postId);
+  }
+
   private buildUpdatePostPayload(updatePostDto: UpdatePostDto): UpdatePostPayloadDto {
     const { categoryId, ...updatePostData } = updatePostDto;
 
@@ -164,23 +182,5 @@ export class PostService {
 
     if (updatePostDto.categoryId !== undefined)
       await this.postCategoryService.findPostCategoryById(updatePostDto.categoryId);
-  }
-
-  validatePostAuthor(currentUserId: number, authorId: number): void {
-    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
-  }
-
-  private async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
-    const post = await this.postRepository.findPostById(postId, manager);
-
-    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
-
-    return post;
-  }
-
-  private async increasePostViewCount(postId: number): Promise<void> {
-    await this.findPostByIdOrThrow(postId);
-
-    await this.postRepository.increaseViewCount(postId);
   }
 }

--- a/test/comments-create.e2e-spec.ts
+++ b/test/comments-create.e2e-spec.ts
@@ -1,0 +1,193 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { CommentLike } from '../src/comments/entities/comment-like.entity';
+import { Comment } from '../src/comments/entities/comment.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { Post } from '../src/posts/entities/post.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Comments Create (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(CommentLike).execute();
+    await dataSource.createQueryBuilder().delete().from(Comment).execute();
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPost(
+    userId: number,
+    categoryId: number,
+    overrides?: Partial<Pick<Post, 'title' | 'content' | 'isAnonymous'>>,
+  ): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: overrides?.title ?? '댓글 테스트용 게시글',
+      content: overrides?.content ?? '댓글이 달릴 게시글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      user: { id: userId },
+      category: { id: categoryId },
+    });
+  }
+
+  it('POST /posts/:id/comments 댓글 작성 성공', async () => {
+    const signupResponse = await signupUser('commenter@example.com', 'commenter');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '저도 같은 생각입니다.',
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toEqual(expect.any(Number));
+    expect(response.body.content).toBe('저도 같은 생각입니다.');
+    expect(response.body.likeCount).toBe(0);
+    expect(response.body.user).toEqual({
+      id: signupResponse.body.user.id,
+      nickname: 'commenter',
+    });
+    expect(response.body.createdAt).toEqual(expect.any(String));
+
+    const createdComment = await dataSource.getRepository(Comment).findOne({
+      where: { id: response.body.id },
+      relations: {
+        user: true,
+        post: true,
+      },
+    });
+
+    expect(createdComment).toBeDefined();
+    expect(createdComment?.content).toBe('저도 같은 생각입니다.');
+    expect(createdComment?.likeCount).toBe(0);
+    expect(createdComment?.isAnonymous).toBe(false);
+    expect(createdComment?.user.id).toBe(signupResponse.body.user.id);
+    expect(createdComment?.post.id).toBe(post.id);
+
+    const updatedPost = await dataSource.getRepository(Post).findOneBy({ id: post.id });
+    expect(updatedPost?.commentCount).toBe(1);
+  });
+
+  it('POST /posts/:id/comments 익명 댓글 작성 성공 시 user는 null', async () => {
+    const signupResponse = await signupUser('anonymous-commenter@example.com', 'anon-commenter');
+    const category = await createCategory('질문');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '익명으로 남기는 댓글입니다.',
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.user).toBeNull();
+  });
+
+  it('POST /posts/:id/comments 존재하지 않는 게시글이면 실패', async () => {
+    const signupResponse = await signupUser('missing-post@example.com', 'missing-post');
+
+    const response = await request(httpApp())
+      .post('/posts/999/comments')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '없는 게시글에 다는 댓글',
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
+  });
+
+  it('POST /posts/:id/comments 잘못된 요청값이면 실패', async () => {
+    const signupResponse = await signupUser('invalid-comment@example.com', 'invalid-comment');
+    const category = await createCategory('정보');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining([
+        'content should not be empty',
+        'isAnonymous should not be empty',
+        'isAnonymous must be a boolean value',
+      ]),
+    );
+
+    const comments = await dataSource.getRepository(Comment).find();
+    expect(comments).toHaveLength(0);
+
+    const unchangedPost = await dataSource.getRepository(Post).findOneBy({ id: post.id });
+    expect(unchangedPost?.commentCount).toBe(0);
+  });
+
+  it('POST /posts/:id/comments 인증 없이 요청하면 실패', async () => {
+    const signupResponse = await signupUser('post-owner@example.com', 'post-owner');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp()).post(`/posts/${post.id}/comments`).send({
+      content: '로그인 없이 작성하는 댓글',
+      isAnonymous: false,
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
+  });
+});


### PR DESCRIPTION
## 연관된 이슈

- #이슈번호

## 📝 작업 내용

- [x] `POST /posts/:postId/comments` 댓글 작성 API 구현
- [x] `CommentController`에 댓글 작성 엔드포인트 추가
- [x] 엔티티에 익명 여부 필드 추가
- [x] 댓글 작성 DTO 정의
- [x] 댓글 작성 Swagger 문서화 추가
- [x] 로그인한 사용자만 댓글 작성 가능하도록 인증 적용
- [x] 댓글 작성 대상 게시글 존재 여부 검증 추가
- [x] 댓글 작성 성공 응답 DTO 정의 및 매핑
- [x] 댓글 작성 단위 테스트 추가
- [x] 댓글 작성 e2e 테스트 추가
- [x] 연결된 게시판 댓글수 증가 트랜잭션 구현
