### PR TITLE
댓글 목록 조회 API 구현

### DIFF
--- a/migrations/1775977285817-AddIsAnonymousInComment.ts
+++ b/migrations/1775977285817-AddIsAnonymousInComment.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsAnonymousInComment1775977285817 implements MigrationInterface {
+    name = 'AddIsAnonymousInComment1775977285817'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" ADD "is_anonymous" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "comments" DROP COLUMN "is_anonymous"`);
+    }
+
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Comment } from './entities/comment.entity';
 import { CommentLike } from './entities/comment-like.entity';
+import { CommentService } from './comments.service';
+import { CommentRepository } from './comments.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment, CommentLike])],
   controllers: [],
-  providers: [],
+  providers: [CommentService, CommentRepository],
 })
 export class CommentModule {}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -4,10 +4,13 @@ import { Comment } from './entities/comment.entity';
 import { CommentLike } from './entities/comment-like.entity';
 import { CommentService } from './comments.service';
 import { CommentRepository } from './comments.repository';
+import { Post } from 'src/posts/entities/post.entity';
+import { PostRepository } from 'src/posts/posts.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment, CommentLike])],
+  imports: [TypeOrmModule.forFeature([Comment, CommentLike, Post])],
   controllers: [],
-  providers: [CommentService, CommentRepository],
+  providers: [CommentService, CommentRepository, PostRepository],
+  exports: [CommentService],
 })
 export class CommentModule {}

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -6,7 +6,7 @@ import { UpdateCommentDto } from './dtos/update-comment.dto';
 
 describe('CommentRepository', () => {
   let commentRepository: CommentRepository;
-  let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'update'>;
+  let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'find' | 'update'>;
   const manager = {
     save: jest.fn(),
     softDelete: jest.fn(),
@@ -15,6 +15,7 @@ describe('CommentRepository', () => {
   beforeEach(() => {
     commentOrmRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
       update: jest.fn(),
     };
 
@@ -91,6 +92,56 @@ describe('CommentRepository', () => {
 
       expect(result).toEqual(updateResult);
       expect(commentOrmRepository.update).toHaveBeenCalledWith(11, updateCommentDto);
+    });
+  });
+
+  describe('findCommentsByPostId', () => {
+    it('postId와 cursor, limit 조건으로 find를 호출한다', async () => {
+      const comments = [
+        { id: 2, content: '두 번째 댓글' },
+        { id: 3, content: '세 번째 댓글' },
+      ];
+
+      (commentOrmRepository.find as jest.Mock).mockResolvedValue(comments);
+
+      const result = await commentRepository.findCommentsByPostId(3, 1, 2);
+
+      expect(result).toEqual(comments);
+      expect(commentOrmRepository.find).toHaveBeenCalledWith({
+        where: {
+          post: { id: 3 },
+          id: expect.any(Object),
+        },
+        relations: {
+          user: true,
+        },
+        order: {
+          id: 'ASC',
+        },
+        take: 3,
+      });
+    });
+
+    it('cursor가 없으면 postId 조건만으로 find를 호출한다', async () => {
+      const comments = [{ id: 1, content: '첫 번째 댓글' }];
+
+      (commentOrmRepository.find as jest.Mock).mockResolvedValue(comments);
+
+      const result = await commentRepository.findCommentsByPostId(3, null, 20);
+
+      expect(result).toEqual(comments);
+      expect(commentOrmRepository.find).toHaveBeenCalledWith({
+        where: {
+          post: { id: 3 },
+        },
+        relations: {
+          user: true,
+        },
+        order: {
+          id: 'ASC',
+        },
+        take: 21,
+      });
     });
   });
 

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -2,10 +2,11 @@ import { Repository } from 'typeorm';
 import { CommentRepository } from './comments.repository';
 import { Comment } from './entities/comment.entity';
 import { CreateCommentDto } from './dtos/create-comment.dto';
+import { UpdateCommentDto } from './dtos/update-comment.dto';
 
 describe('CommentRepository', () => {
   let commentRepository: CommentRepository;
-  let commentOrmRepository: Pick<Repository<Comment>, 'findOne'>;
+  let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'update'>;
   const manager = {
     save: jest.fn(),
   };
@@ -13,6 +14,7 @@ describe('CommentRepository', () => {
   beforeEach(() => {
     commentOrmRepository = {
       findOne: jest.fn(),
+      update: jest.fn(),
     };
 
     commentRepository = new CommentRepository(commentOrmRepository as Repository<Comment>);
@@ -48,8 +50,8 @@ describe('CommentRepository', () => {
     });
   });
 
-  describe('findCommentById', () => {
-    it('commentId로 findOne을 호출', async () => {
+  describe('findByCommentIdAndPostId', () => {
+    it('commentId와 postId로 findOne을 호출', async () => {
       const comment = {
         id: 11,
         content: '댓글',
@@ -57,17 +59,37 @@ describe('CommentRepository', () => {
 
       (commentOrmRepository.findOne as jest.Mock).mockResolvedValue(comment);
 
-      const result = await commentRepository.findCommentById(11);
+      const result = await commentRepository.findByCommentIdAndPostId(11, 3);
 
       expect(result).toEqual(comment);
       expect(commentOrmRepository.findOne).toHaveBeenCalledWith({
         where: {
           id: 11,
+          post: { id: 3 },
         },
         relations: {
           user: true,
+          post: true,
         },
       });
+    });
+  });
+
+  describe('updateComment', () => {
+    it('commentId와 수정 DTO로 update를 호출한다', async () => {
+      const updateCommentDto: UpdateCommentDto = {
+        content: '수정된 댓글',
+      };
+      const updateResult = {
+        affected: 1,
+      };
+
+      (commentOrmRepository.update as jest.Mock).mockResolvedValue(updateResult);
+
+      const result = await commentRepository.updateComment(updateCommentDto, 11);
+
+      expect(result).toEqual(updateResult);
+      expect(commentOrmRepository.update).toHaveBeenCalledWith(11, updateCommentDto);
     });
   });
 });

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -1,0 +1,73 @@
+import { Repository } from 'typeorm';
+import { CommentRepository } from './comments.repository';
+import { Comment } from './entities/comment.entity';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+
+describe('CommentRepository', () => {
+  let commentRepository: CommentRepository;
+  let commentOrmRepository: Pick<Repository<Comment>, 'findOne'>;
+  const manager = {
+    save: jest.fn(),
+  };
+
+  beforeEach(() => {
+    commentOrmRepository = {
+      findOne: jest.fn(),
+    };
+
+    commentRepository = new CommentRepository(commentOrmRepository as Repository<Comment>);
+  });
+
+  describe('createComment', () => {
+    it('createCommentDTO, postId, userId로 manager.save를 호출', async () => {
+      const createCommentDto: CreateCommentDto = {
+        content: '저도 같은 생각입니다.',
+        isAnonymous: false,
+      };
+      const savedComment = {
+        id: 11,
+        ...createCommentDto,
+      };
+
+      (manager.save as jest.Mock).mockResolvedValue(savedComment);
+
+      const result = await commentRepository.createComment(
+        createCommentDto,
+        3,
+        7,
+        manager as never,
+      );
+
+      expect(result).toEqual(savedComment);
+      expect(manager.save).toHaveBeenCalledWith(Comment, {
+        content: createCommentDto.content,
+        isAnonymous: createCommentDto.isAnonymous,
+        post: { id: 3 },
+        user: { id: 7 },
+      });
+    });
+  });
+
+  describe('findCommentById', () => {
+    it('commentId로 findOne을 호출', async () => {
+      const comment = {
+        id: 11,
+        content: '댓글',
+      };
+
+      (commentOrmRepository.findOne as jest.Mock).mockResolvedValue(comment);
+
+      const result = await commentRepository.findCommentById(11);
+
+      expect(result).toEqual(comment);
+      expect(commentOrmRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: 11,
+        },
+        relations: {
+          user: true,
+        },
+      });
+    });
+  });
+});

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -9,6 +9,7 @@ describe('CommentRepository', () => {
   let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'update'>;
   const manager = {
     save: jest.fn(),
+    softDelete: jest.fn(),
   };
 
   beforeEach(() => {
@@ -90,6 +91,21 @@ describe('CommentRepository', () => {
 
       expect(result).toEqual(updateResult);
       expect(commentOrmRepository.update).toHaveBeenCalledWith(11, updateCommentDto);
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('commentId로 manager.softDelete를 호출한다', async () => {
+      const deleteResult = {
+        affected: 1,
+      };
+
+      (manager.softDelete as jest.Mock).mockResolvedValue(deleteResult);
+
+      const result = await commentRepository.deleteComment(11, manager as never);
+
+      expect(result).toEqual(deleteResult);
+      expect(manager.softDelete).toHaveBeenCalledWith(Comment, 11);
     });
   });
 });

--- a/src/comments/comments.repository.spec.ts
+++ b/src/comments/comments.repository.spec.ts
@@ -2,11 +2,10 @@ import { Repository } from 'typeorm';
 import { CommentRepository } from './comments.repository';
 import { Comment } from './entities/comment.entity';
 import { CreateCommentDto } from './dtos/create-comment.dto';
-import { UpdateCommentDto } from './dtos/update-comment.dto';
 
 describe('CommentRepository', () => {
   let commentRepository: CommentRepository;
-  let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'update'>;
+  let commentOrmRepository: Pick<Repository<Comment>, 'findOne' | 'save'>;
   const manager = {
     save: jest.fn(),
   };
@@ -14,7 +13,7 @@ describe('CommentRepository', () => {
   beforeEach(() => {
     commentOrmRepository = {
       findOne: jest.fn(),
-      update: jest.fn(),
+      save: jest.fn(),
     };
 
     commentRepository = new CommentRepository(commentOrmRepository as Repository<Comment>);
@@ -76,20 +75,23 @@ describe('CommentRepository', () => {
   });
 
   describe('updateComment', () => {
-    it('commentId와 수정 DTO로 update를 호출한다', async () => {
-      const updateCommentDto: UpdateCommentDto = {
+    it('수정된 comment entity로 save를 호출한다', async () => {
+      const comment = {
+        id: 11,
         content: '수정된 댓글',
+        isAnonymous: false,
       };
-      const updateResult = {
-        affected: 1,
+      const savedComment = {
+        ...comment,
+        createdAt: '2026-04-20T00:00:00.000Z',
       };
 
-      (commentOrmRepository.update as jest.Mock).mockResolvedValue(updateResult);
+      (commentOrmRepository.save as jest.Mock).mockResolvedValue(savedComment);
 
-      const result = await commentRepository.updateComment(updateCommentDto, 11);
+      const result = await commentRepository.updateComment(comment as Comment);
 
-      expect(result).toEqual(updateResult);
-      expect(commentOrmRepository.update).toHaveBeenCalledWith(11, updateCommentDto);
+      expect(result).toEqual(savedComment);
+      expect(commentOrmRepository.save).toHaveBeenCalledWith(comment);
     });
   });
 });

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,7 +1,7 @@
 import { UpdateCommentDto } from './dtos/update-comment.dto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, FindOptionsWhere, MoreThan, Repository } from 'typeorm';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { Comment } from './entities/comment.entity';
 import { UpdateResult } from 'typeorm';
@@ -30,6 +30,26 @@ export class CommentRepository {
     return await this.commentRepository.findOne({
       where: { id: commentId, post: { id: postId } },
       relations: { user: true, post: true },
+    });
+  }
+
+  async findCommentsByPostId(
+    postId: number,
+    cursor: number | null,
+    limit: number,
+  ): Promise<Comment[]> {
+    const where: FindOptionsWhere<Comment> = {};
+
+    where.post = { id: postId };
+    if (cursor) where.id = MoreThan(cursor);
+
+    return await this.commentRepository.find({
+      where,
+      relations: { user: true },
+      order: {
+        id: 'ASC',
+      },
+      take: limit + 1,
     });
   }
 

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+import { Comment } from './entities/comment.entity';
 
 @Injectable()
 export class CommentRepository {
@@ -8,4 +10,24 @@ export class CommentRepository {
     @InjectRepository(Comment)
     private readonly commentRepository: Repository<Comment>,
   ) {}
+
+  async createComment(
+    createCommentDto: CreateCommentDto,
+    postId: number,
+    userId: number,
+    manager: EntityManager,
+  ) {
+    return await manager.save(Comment, {
+      ...createCommentDto,
+      post: { id: postId },
+      user: { id: userId },
+    });
+  }
+
+  async findCommentById(commentId: number): Promise<Comment | null> {
+    return await this.commentRepository.findOne({
+      where: { id: commentId },
+      relations: { user: true },
+    });
+  }
 }

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,8 +1,10 @@
+import { UpdateCommentDto } from './dtos/update-comment.dto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { Comment } from './entities/comment.entity';
+import { UpdateResult } from 'typeorm';
 
 @Injectable()
 export class CommentRepository {
@@ -16,7 +18,7 @@ export class CommentRepository {
     postId: number,
     userId: number,
     manager: EntityManager,
-  ) {
+  ): Promise<Comment> {
     return await manager.save(Comment, {
       ...createCommentDto,
       post: { id: postId },
@@ -24,10 +26,17 @@ export class CommentRepository {
     });
   }
 
-  async findCommentById(commentId: number): Promise<Comment | null> {
+  async findByCommentIdAndPostId(commentId: number, postId: number): Promise<Comment | null> {
     return await this.commentRepository.findOne({
-      where: { id: commentId },
-      relations: { user: true },
+      where: { id: commentId, post: { id: postId } },
+      relations: { user: true, post: true },
     });
+  }
+
+  async updateComment(
+    updateCommentDto: UpdateCommentDto,
+    commentId: number,
+  ): Promise<UpdateResult> {
+    return await this.commentRepository.update(commentId, updateCommentDto);
   }
 }

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -39,4 +39,8 @@ export class CommentRepository {
   ): Promise<UpdateResult> {
     return await this.commentRepository.update(commentId, updateCommentDto);
   }
+
+  async deleteComment(commentId: number, manager: EntityManager): Promise<UpdateResult> {
+    return await manager.softDelete(Comment, commentId);
+  }
 }

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CommentRepository {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) {}
+}

--- a/src/comments/comments.repository.ts
+++ b/src/comments/comments.repository.ts
@@ -1,4 +1,3 @@
-import { UpdateCommentDto } from './dtos/update-comment.dto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
@@ -33,10 +32,7 @@ export class CommentRepository {
     });
   }
 
-  async updateComment(
-    updateCommentDto: UpdateCommentDto,
-    commentId: number,
-  ): Promise<UpdateResult> {
-    return await this.commentRepository.update(commentId, updateCommentDto);
+  async updateComment(comment: Comment): Promise<Comment> {
+    return await this.commentRepository.save(comment);
   }
 }

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -163,17 +163,16 @@ describe('CommentService', () => {
       };
 
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
-      mockCommentRepository.findByCommentIdAndPostId
-        .mockResolvedValueOnce(mockCommentEntity)
-        .mockResolvedValueOnce(updatedCommentEntity);
-      mockCommentRepository.updateComment.mockResolvedValue({ affected: 1 });
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
+      mockCommentRepository.updateComment.mockResolvedValue(updatedCommentEntity);
 
       const result = await commentService.editComment(updateCommentDto, 3, 11, 7);
 
       expect(result).toEqual(updatedCommentEntity);
-      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenNthCalledWith(1, 11, 3);
-      expect(mockCommentRepository.updateComment).toHaveBeenCalledWith(updateCommentDto, 11);
-      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenNthCalledWith(2, 11, 3);
+      expect(mockCommentRepository.updateComment).toHaveBeenCalledWith({
+        ...mockCommentEntity,
+        content: '수정된 댓글입니다.',
+      });
     });
 
     it('작성자가 아니면 ForbiddenException을 던진다', async () => {
@@ -203,22 +202,6 @@ describe('CommentService', () => {
       );
 
       expect(mockCommentRepository.findByCommentIdAndPostId).not.toHaveBeenCalled();
-    });
-
-    it('수정 후 댓글을 다시 조회하지 못하면 InternalServerErrorException을 던진다', async () => {
-      const updateCommentDto: UpdateCommentDto = {
-        content: '수정 시도',
-      };
-
-      mockPostRepository.findPostById.mockResolvedValue(mockPost);
-      mockCommentRepository.findByCommentIdAndPostId
-        .mockResolvedValueOnce(mockCommentEntity)
-        .mockResolvedValueOnce(null);
-      mockCommentRepository.updateComment.mockResolvedValue({ affected: 1 });
-
-      await expect(commentService.editComment(updateCommentDto, 3, 11, 7)).rejects.toThrow(
-        InternalServerErrorException,
-      );
     });
   });
 });

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -40,11 +40,13 @@ const mockCommentRepository = {
   createComment: jest.fn(),
   findByCommentIdAndPostId: jest.fn(),
   updateComment: jest.fn(),
+  deleteComment: jest.fn(),
 };
 
 const mockPostRepository = {
   findPostById: jest.fn(),
   increaseCommentCount: jest.fn(),
+  decreaseCommentCount: jest.fn(),
 };
 
 const mockManager = {} as EntityManager;
@@ -201,6 +203,51 @@ describe('CommentService', () => {
       );
 
       expect(mockCommentRepository.findByCommentIdAndPostId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('작성자가 댓글을 삭제하면 댓글 수를 감소시킨다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
+      mockCommentRepository.deleteComment.mockResolvedValue({ affected: 1 });
+      mockPostRepository.decreaseCommentCount.mockResolvedValue({ affected: 1 });
+
+      await expect(commentService.deleteComment(3, 11, 7)).resolves.toBeUndefined();
+
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
+      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenCalledWith(11, 3);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockCommentRepository.deleteComment).toHaveBeenCalledWith(11, mockManager);
+      expect(mockPostRepository.decreaseCommentCount).toHaveBeenCalledWith(3, mockManager);
+    });
+
+    it('작성자가 아니면 ForbiddenException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
+
+      await expect(commentService.deleteComment(3, 11, 8)).rejects.toThrow(ForbiddenException);
+
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+      expect(mockCommentRepository.deleteComment).not.toHaveBeenCalled();
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(commentService.deleteComment(999, 11, 7)).rejects.toThrow(NotFoundException);
+
+      expect(mockCommentRepository.findByCommentIdAndPostId).not.toHaveBeenCalled();
+    });
+
+    it('트랜잭션에서 삭제 결과가 없으면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
+      mockCommentRepository.deleteComment.mockResolvedValue({ affected: 0 });
+
+      await expect(commentService.deleteComment(3, 11, 7)).rejects.toThrow(NotFoundException);
+
+      expect(mockPostRepository.decreaseCommentCount).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 import { CommentService } from './comments.service';
 import { CommentRepository } from './comments.repository';
 import { PostRepository } from 'src/posts/posts.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
+import { UpdateCommentDto } from './dtos/update-comment.dto';
 
 const createCommentDto: CreateCommentDto = {
   content: '저도 같은 생각입니다.',
@@ -26,6 +27,9 @@ const mockCommentEntity = {
   likeCount: 0,
   isAnonymous: false,
   createdAt: '2026-04-16T00:00:00.000Z',
+  post: {
+    id: 3,
+  },
   user: {
     id: 7,
     nickname: 'commenter',
@@ -34,7 +38,8 @@ const mockCommentEntity = {
 
 const mockCommentRepository = {
   createComment: jest.fn(),
-  findCommentById: jest.fn(),
+  findByCommentIdAndPostId: jest.fn(),
+  updateComment: jest.fn(),
 };
 
 const mockPostRepository = {
@@ -87,7 +92,7 @@ describe('CommentService', () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
       mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
       mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
-      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
 
       const result = await commentService.createComment(createCommentDto, 3, 7);
 
@@ -101,7 +106,7 @@ describe('CommentService', () => {
         mockManager,
       );
       expect(mockPostRepository.increaseCommentCount).toHaveBeenCalledWith(3, mockManager);
-      expect(mockCommentRepository.findCommentById).toHaveBeenCalledWith(11);
+      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenCalledWith(11, 3);
     });
 
     it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
@@ -119,7 +124,7 @@ describe('CommentService', () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
       mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
       mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
-      mockCommentRepository.findCommentById.mockResolvedValue(null);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(null);
 
       await expect(commentService.createComment(createCommentDto, 3, 7)).rejects.toThrow(
         NotFoundException,
@@ -127,19 +132,75 @@ describe('CommentService', () => {
     });
   });
 
-  describe('findCommentById', () => {
+  describe('findByCommentIdAndPostId', () => {
     it('댓글 상세 정보를 반환한다', async () => {
-      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
 
-      const result = await commentService.findCommentById(11);
+      const result = await commentService.findByCommentIdAndPostId(11, 3);
 
       expect(result).toEqual(mockCommentEntity);
     });
 
     it('존재하지 않는 댓글이면 NotFoundException을 던진다', async () => {
-      mockCommentRepository.findCommentById.mockResolvedValue(null);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(null);
 
-      await expect(commentService.findCommentById(999)).rejects.toThrow(NotFoundException);
+      await expect(commentService.findByCommentIdAndPostId(999, 3)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('editComment', () => {
+    it('작성자가 댓글을 수정하면 수정 후 댓글 상세 정보를 반환한다', async () => {
+      const updateCommentDto: UpdateCommentDto = {
+        content: '수정된 댓글입니다.',
+      };
+      const updatedCommentEntity = {
+        ...mockCommentEntity,
+        content: '수정된 댓글입니다.',
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findByCommentIdAndPostId
+        .mockResolvedValueOnce(mockCommentEntity)
+        .mockResolvedValueOnce(updatedCommentEntity);
+      mockCommentRepository.updateComment.mockResolvedValue({ affected: 1 });
+
+      const result = await commentService.editComment(updateCommentDto, 3, 11, 7);
+
+      expect(result).toEqual(updatedCommentEntity);
+      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenNthCalledWith(1, 11, 3);
+      expect(mockCommentRepository.updateComment).toHaveBeenCalledWith(updateCommentDto, 11);
+      expect(mockCommentRepository.findByCommentIdAndPostId).toHaveBeenNthCalledWith(2, 11, 3);
+    });
+
+    it('작성자가 아니면 ForbiddenException을 던진다', async () => {
+      const updateCommentDto: UpdateCommentDto = {
+        content: '수정 시도',
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
+
+      await expect(commentService.editComment(updateCommentDto, 3, 11, 8)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(mockCommentRepository.updateComment).not.toHaveBeenCalled();
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      const updateCommentDto: UpdateCommentDto = {
+        content: '수정 시도',
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(commentService.editComment(updateCommentDto, 999, 11, 7)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockCommentRepository.findByCommentIdAndPostId).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 import { CommentService } from './comments.service';
 import { CommentRepository } from './comments.repository';
@@ -115,14 +115,14 @@ describe('CommentService', () => {
       expect(mockCommentRepository.createComment).not.toHaveBeenCalled();
     });
 
-    it('생성 후 댓글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+    it('생성 후 댓글을 다시 조회하지 못하면 InternalServerErrorException을 던진다', async () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
       mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
       mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
       mockCommentRepository.findCommentById.mockResolvedValue(null);
 
       await expect(commentService.createComment(createCommentDto, 3, 7)).rejects.toThrow(
-        NotFoundException,
+        InternalServerErrorException,
       );
     });
   });
@@ -136,10 +136,10 @@ describe('CommentService', () => {
       expect(result).toEqual(mockCommentEntity);
     });
 
-    it('존재하지 않는 댓글이면 NotFoundException을 던진다', async () => {
+    it('존재하지 않는 댓글이면 null을 반환한다', async () => {
       mockCommentRepository.findCommentById.mockResolvedValue(null);
 
-      await expect(commentService.findCommentById(999)).rejects.toThrow(NotFoundException);
+      await expect(commentService.findCommentById(999)).resolves.toBeNull();
     });
   });
 });

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+import { CommentService } from './comments.service';
+import { CommentRepository } from './comments.repository';
+import { PostRepository } from 'src/posts/posts.repository';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+
+const createCommentDto: CreateCommentDto = {
+  content: '저도 같은 생각입니다.',
+  isAnonymous: false,
+};
+
+const mockPost = {
+  id: 3,
+  title: '댓글이 달릴 게시글',
+};
+
+const mockCreatedComment = {
+  id: 11,
+};
+
+const mockCommentEntity = {
+  id: 11,
+  content: createCommentDto.content,
+  likeCount: 0,
+  isAnonymous: false,
+  createdAt: '2026-04-16T00:00:00.000Z',
+  user: {
+    id: 7,
+    nickname: 'commenter',
+  },
+};
+
+const mockCommentRepository = {
+  createComment: jest.fn(),
+  findCommentById: jest.fn(),
+};
+
+const mockPostRepository = {
+  findPostById: jest.fn(),
+  increaseCommentCount: jest.fn(),
+};
+
+const mockManager = {} as EntityManager;
+
+const mockDataSource = {
+  transaction: jest.fn(),
+};
+
+describe('CommentService', () => {
+  let commentService: CommentService;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+
+    mockDataSource.transaction.mockImplementation(
+      async <T>(callback: (manager: EntityManager) => Promise<T>): Promise<T> => {
+        return callback(mockManager);
+      },
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: CommentRepository,
+          useValue: mockCommentRepository,
+        },
+        {
+          provide: PostRepository,
+          useValue: mockPostRepository,
+        },
+      ],
+    }).compile();
+
+    commentService = module.get<CommentService>(CommentService);
+  });
+
+  describe('createComment', () => {
+    it('게시글을 검증하고 댓글 생성 후 상세 정보를 반환한다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
+      mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
+      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+
+      const result = await commentService.createComment(createCommentDto, 3, 7);
+
+      expect(result).toEqual(mockCommentEntity);
+      expect(mockPostRepository.findPostById).toHaveBeenCalledWith(3);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockCommentRepository.createComment).toHaveBeenCalledWith(
+        createCommentDto,
+        3,
+        7,
+        mockManager,
+      );
+      expect(mockPostRepository.increaseCommentCount).toHaveBeenCalledWith(3, mockManager);
+      expect(mockCommentRepository.findCommentById).toHaveBeenCalledWith(11);
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(commentService.createComment(createCommentDto, 999, 7)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+      expect(mockCommentRepository.createComment).not.toHaveBeenCalled();
+    });
+
+    it('생성 후 댓글을 다시 조회하지 못하면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.createComment.mockResolvedValue(mockCreatedComment);
+      mockPostRepository.increaseCommentCount.mockResolvedValue({ affected: 1 });
+      mockCommentRepository.findCommentById.mockResolvedValue(null);
+
+      await expect(commentService.createComment(createCommentDto, 3, 7)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findCommentById', () => {
+    it('댓글 상세 정보를 반환한다', async () => {
+      mockCommentRepository.findCommentById.mockResolvedValue(mockCommentEntity);
+
+      const result = await commentService.findCommentById(11);
+
+      expect(result).toEqual(mockCommentEntity);
+    });
+
+    it('존재하지 않는 댓글이면 NotFoundException을 던진다', async () => {
+      mockCommentRepository.findCommentById.mockResolvedValue(null);
+
+      await expect(commentService.findCommentById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -6,6 +6,7 @@ import { CommentRepository } from './comments.repository';
 import { PostRepository } from 'src/posts/posts.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { UpdateCommentDto } from './dtos/update-comment.dto';
+import { FindCommentsQueryDto } from './dtos/find-comments-query.dto';
 
 const createCommentDto: CreateCommentDto = {
   content: '저도 같은 생각입니다.',
@@ -36,9 +37,28 @@ const mockCommentEntity = {
   },
 };
 
+const mockCommentList = [
+  {
+    ...mockCommentEntity,
+    id: 1,
+    content: '첫 번째 댓글',
+  },
+  {
+    ...mockCommentEntity,
+    id: 2,
+    content: '두 번째 댓글',
+  },
+  {
+    ...mockCommentEntity,
+    id: 3,
+    content: '세 번째 댓글',
+  },
+];
+
 const mockCommentRepository = {
   createComment: jest.fn(),
   findByCommentIdAndPostId: jest.fn(),
+  findCommentsByPostId: jest.fn(),
   updateComment: jest.fn(),
   deleteComment: jest.fn(),
 };
@@ -149,6 +169,55 @@ describe('CommentService', () => {
       await expect(commentService.findByCommentIdAndPostId(999, 3)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('findCommentsByPostId', () => {
+    it('게시글이 존재하면 댓글 목록을 반환한다', async () => {
+      const query: FindCommentsQueryDto = {
+        limit: 20,
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findCommentsByPostId.mockResolvedValue(mockCommentList.slice(0, 2));
+
+      const result = await commentService.findCommentsByPostId(3, query);
+
+      expect(result).toEqual({
+        items: mockCommentList.slice(0, 2),
+        nextCursor: null,
+        hasNext: false,
+      });
+      expect(mockCommentRepository.findCommentsByPostId).toHaveBeenCalledWith(3, null, 20);
+    });
+
+    it('다음 페이지가 있으면 limit 만큼 자르고 nextCursor를 반환한다', async () => {
+      const query: FindCommentsQueryDto = {
+        cursor: 1,
+        limit: 2,
+      };
+
+      mockPostRepository.findPostById.mockResolvedValue(mockPost);
+      mockCommentRepository.findCommentsByPostId.mockResolvedValue(mockCommentList);
+
+      const result = await commentService.findCommentsByPostId(3, query);
+
+      expect(result).toEqual({
+        items: mockCommentList.slice(0, 2),
+        nextCursor: 2,
+        hasNext: true,
+      });
+      expect(mockCommentRepository.findCommentsByPostId).toHaveBeenCalledWith(3, 1, 2);
+    });
+
+    it('존재하지 않는 게시글이면 NotFoundException을 던진다', async () => {
+      mockPostRepository.findPostById.mockResolvedValue(null);
+
+      await expect(commentService.findCommentsByPostId(999, {})).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockCommentRepository.findCommentsByPostId).not.toHaveBeenCalled();
     });
   });
 

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -241,12 +241,14 @@ describe('CommentService', () => {
       expect(mockCommentRepository.findByCommentIdAndPostId).not.toHaveBeenCalled();
     });
 
-    it('트랜잭션에서 삭제 결과가 없으면 NotFoundException을 던진다', async () => {
+    it('트랜잭션에서 삭제 결과가 없으면 InternalServerErrorException을 던진다', async () => {
       mockPostRepository.findPostById.mockResolvedValue(mockPost);
       mockCommentRepository.findByCommentIdAndPostId.mockResolvedValue(mockCommentEntity);
       mockCommentRepository.deleteComment.mockResolvedValue({ affected: 0 });
 
-      await expect(commentService.deleteComment(3, 11, 7)).rejects.toThrow(NotFoundException);
+      await expect(commentService.deleteComment(3, 11, 7)).rejects.toThrow(
+        InternalServerErrorException,
+      );
 
       expect(mockPostRepository.decreaseCommentCount).not.toHaveBeenCalled();
     });

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -72,11 +72,10 @@ export class CommentService {
     if (existingComment.user.id !== userId)
       throw new ForbiddenException('댓글을 수정할 권한이 없습니다.');
 
-    await this.commentRepository.updateComment(updateCommentDto, commentId);
+    if (updateCommentDto.content !== undefined) existingComment.content = updateCommentDto.content;
+    if (updateCommentDto.isAnonymous !== undefined)
+      existingComment.isAnonymous = updateCommentDto.isAnonymous;
 
-    const updatedComment = await this.commentRepository.findByCommentIdAndPostId(commentId, postId);
-    if (!updatedComment) throw new InternalServerErrorException('수정된 댓글 조회에 실패했습니다.');
-
-    return updatedComment;
+    return await this.commentRepository.updateComment(existingComment);
   }
 }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -90,7 +90,8 @@ export class CommentService {
 
     await this.dataSource.transaction(async (manager) => {
       const deletedResult = await this.commentRepository.deleteComment(commentId, manager);
-      if (!deletedResult.affected) throw new NotFoundException('존재하지 않는 댓글입니다.');
+      if (!deletedResult.affected)
+        throw new InternalServerErrorException('댓글 삭제에 실패했습니다.');
 
       await this.postRepository.decreaseCommentCount(postId, manager);
     });

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { CommentRepository } from './comments.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { Comment } from './entities/comment.entity';
 import { PostRepository } from 'src/posts/posts.repository';
 import { DataSource } from 'typeorm';
+import { UpdateCommentDto } from './dtos/update-comment.dto';
 
 @Injectable()
 export class CommentService {
@@ -34,13 +35,32 @@ export class CommentService {
       return createdComment.id;
     });
 
-    return this.findCommentById(createdCommentId);
+    return this.findByCommentIdAndPostId(createdCommentId, postId);
   }
 
-  async findCommentById(commentId: number): Promise<Comment> {
-    const comment = await this.commentRepository.findCommentById(commentId);
+  async findByCommentIdAndPostId(commentId: number, postId: number): Promise<Comment> {
+    const comment = await this.commentRepository.findByCommentIdAndPostId(commentId, postId);
     if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
 
     return comment;
+  }
+
+  async editComment(
+    updateCommentDto: UpdateCommentDto,
+    postId: number,
+    commentId: number,
+    userId: number,
+  ): Promise<Comment> {
+    const existingPost = await this.postRepository.findPostById(postId);
+    if (!existingPost) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    const existingComment = await this.findByCommentIdAndPostId(commentId, postId);
+
+    if (existingComment.user.id !== userId)
+      throw new ForbiddenException('댓글을 수정할 권한이 없습니다.');
+
+    await this.commentRepository.updateComment(updateCommentDto, commentId);
+
+    return this.findByCommentIdAndPostId(commentId, postId);
   }
 }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -63,4 +63,21 @@ export class CommentService {
 
     return this.findByCommentIdAndPostId(commentId, postId);
   }
+
+  async deleteComment(postId: number, commentId: number, userId: number): Promise<void> {
+    const existingPost = await this.postRepository.findPostById(postId);
+    if (!existingPost) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    const existingComment = await this.findByCommentIdAndPostId(commentId, postId);
+
+    if (existingComment.user.id !== userId)
+      throw new ForbiddenException('댓글을 삭제할 권한이 없습니다.');
+
+    await this.dataSource.transaction(async (manager) => {
+      const deletedResult = await this.commentRepository.deleteComment(commentId, manager);
+      if (!deletedResult.affected) throw new NotFoundException('존재하지 않는 댓글입니다.');
+
+      await this.postRepository.decreaseCommentCount(postId, manager);
+    });
+  }
 }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { CommentRepository } from './comments.repository';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+import { PostService } from 'src/posts/posts.service';
+
+@Injectable()
+export class CommentService {
+  constructor(
+    private readonly commentRepository: CommentRepository,
+    private readonly postService: PostService,
+  ) {}
+
+  async createComment(
+    createCommentDto: CreateCommentDto,
+    postId: number,
+    userId: number,
+  ): Promise<Comment> {
+    const post = await this.postService.findPostByIdOrThrow(postId);
+
+    // 댓글 저장
+
+    // 저장된 댓글 반환
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { CommentRepository } from './comments.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { Comment } from './entities/comment.entity';
@@ -34,13 +34,13 @@ export class CommentService {
       return createdComment.id;
     });
 
-    return this.findCommentById(createdCommentId);
+    const foundComment = await this.findCommentById(createdCommentId);
+    if (!foundComment) throw new InternalServerErrorException('생성된 댓글 조회에 실패했습니다.');
+
+    return foundComment;
   }
 
-  async findCommentById(commentId: number): Promise<Comment> {
-    const comment = await this.commentRepository.findCommentById(commentId);
-    if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
-
-    return comment;
+  async findCommentById(commentId: number): Promise<Comment | null> {
+    return await this.commentRepository.findCommentById(commentId);
   }
 }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -5,6 +5,9 @@ import { Comment } from './entities/comment.entity';
 import { PostRepository } from 'src/posts/posts.repository';
 import { DataSource } from 'typeorm';
 import { UpdateCommentDto } from './dtos/update-comment.dto';
+import { FindCommentsQueryDto } from './dtos/find-comments-query.dto';
+import { PAGINATION_CONSTANTS } from './constants/comment.constant';
+import { FindCommentsResult } from './types/comment.type';
 
 @Injectable()
 export class CommentService {
@@ -43,6 +46,28 @@ export class CommentService {
     if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
 
     return comment;
+  }
+
+  async findCommentsByPostId(
+    postId: number,
+    findCommentsQueryDto: FindCommentsQueryDto,
+  ): Promise<FindCommentsResult> {
+    const existingPost = await this.postRepository.findPostById(postId);
+    if (!existingPost) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    const limit = findCommentsQueryDto.limit ?? PAGINATION_CONSTANTS.DEFAULT_LIMIT;
+    const cursor = findCommentsQueryDto.cursor ?? null;
+    const comments = await this.commentRepository.findCommentsByPostId(postId, cursor, limit);
+
+    const hasNext = comments.length > limit;
+    const paginatedComments = hasNext ? comments.slice(0, limit) : comments;
+    const nextCursor = hasNext ? paginatedComments[paginatedComments.length - 1].id : null;
+
+    return {
+      items: paginatedComments,
+      nextCursor,
+      hasNext,
+    };
   }
 
   async editComment(

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CommentRepository } from './comments.repository';
 import { CreateCommentDto } from './dtos/create-comment.dto';
-import { PostService } from 'src/posts/posts.service';
+import { Comment } from './entities/comment.entity';
+import { PostRepository } from 'src/posts/posts.repository';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class CommentService {
   constructor(
     private readonly commentRepository: CommentRepository,
-    private readonly postService: PostService,
+    private readonly postRepository: PostRepository,
+    private readonly dataSource: DataSource,
   ) {}
 
   async createComment(
@@ -15,10 +18,29 @@ export class CommentService {
     postId: number,
     userId: number,
   ): Promise<Comment> {
-    const post = await this.postService.findPostByIdOrThrow(postId);
+    const post = await this.postRepository.findPostById(postId);
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
 
-    // 댓글 저장
+    const createdCommentId = await this.dataSource.transaction(async (manager) => {
+      const createdComment = await this.commentRepository.createComment(
+        createCommentDto,
+        postId,
+        userId,
+        manager,
+      );
 
-    // 저장된 댓글 반환
+      await this.postRepository.increaseCommentCount(postId, manager);
+
+      return createdComment.id;
+    });
+
+    return this.findCommentById(createdCommentId);
+  }
+
+  async findCommentById(commentId: number): Promise<Comment> {
+    const comment = await this.commentRepository.findCommentById(commentId);
+    if (!comment) throw new NotFoundException('존재하지 않는 댓글입니다.');
+
+    return comment;
   }
 }

--- a/src/comments/constants/comment.constant.ts
+++ b/src/comments/constants/comment.constant.ts
@@ -1,0 +1,3 @@
+export const COMMENT_CONSTANTS = {
+  MAX_CONTENTS: 500,
+};

--- a/src/comments/constants/comment.constant.ts
+++ b/src/comments/constants/comment.constant.ts
@@ -1,3 +1,10 @@
 export const COMMENT_CONSTANTS = {
   MAX_CONTENTS: 500,
 };
+
+export const PAGINATION_CONSTANTS = {
+  MAX_LIMIT: 50,
+  MIN_LIMIT: 1,
+  DEFAULT_LIMIT: 20,
+  MIN_CURSOR_ID: 1,
+};

--- a/src/comments/dtos/create-comment.dto.ts
+++ b/src/comments/dtos/create-comment.dto.ts
@@ -1,0 +1,20 @@
+import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { COMMENT_CONSTANTS } from '../constants/comment.constant';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCommentDto {
+  @ApiProperty({
+    example: `맞아요. 저도 동의합니다.`,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(COMMENT_CONSTANTS.MAX_CONTENTS)
+  content: string;
+
+  @ApiProperty({
+    example: false,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isAnonymous: boolean;
+}

--- a/src/comments/dtos/find-comments-query.dto.ts
+++ b/src/comments/dtos/find-comments-query.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, Max, Min } from 'class-validator';
+import { PAGINATION_CONSTANTS } from '../constants/comment.constant';
+
+export class FindCommentsQueryDto {
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(PAGINATION_CONSTANTS.MIN_CURSOR_ID)
+  cursor?: number;
+
+  @ApiPropertyOptional({
+    minimum: PAGINATION_CONSTANTS.MIN_LIMIT,
+    maximum: PAGINATION_CONSTANTS.MAX_LIMIT,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(PAGINATION_CONSTANTS.MIN_LIMIT)
+  @Max(PAGINATION_CONSTANTS.MAX_LIMIT)
+  limit?: number;
+}

--- a/src/comments/dtos/response-comment.dto.ts
+++ b/src/comments/dtos/response-comment.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResponseCommentDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  likeCount: number;
+
+  @ApiProperty()
+  user: CommentAuthorDto | null;
+}
+
+export class CommentAuthorDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  nickname: string;
+}

--- a/src/comments/dtos/response-comment.dto.ts
+++ b/src/comments/dtos/response-comment.dto.ts
@@ -24,3 +24,14 @@ export class CommentAuthorDto {
   @ApiProperty()
   nickname: string;
 }
+
+export class ResponseCommentListDto {
+  @ApiProperty()
+  items: ResponseCommentDto[];
+
+  @ApiProperty()
+  nextCursor: number | null;
+
+  @ApiProperty()
+  hasNext: boolean;
+}

--- a/src/comments/dtos/update-comment.dto.ts
+++ b/src/comments/dtos/update-comment.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCommentDto } from './create-comment.dto';
+
+export class UpdateCommentDto extends PartialType(CreateCommentDto) {}

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -20,6 +20,12 @@ export class Comment extends BaseTableEntity {
   })
   likeCount: number;
 
+  @Column({
+    default: false,
+    name: 'is_anonymous',
+  })
+  isAnonymous: boolean;
+
   @OneToMany(() => CommentLike, (commentLike) => commentLike.comment)
   commentLikes: CommentLike[];
 

--- a/src/comments/mappers/comment.mapper.ts
+++ b/src/comments/mappers/comment.mapper.ts
@@ -1,5 +1,9 @@
 import { User } from 'src/users/entities/user.entity';
-import { CommentAuthorDto, ResponseCommentDto } from '../dtos/response-comment.dto';
+import {
+  CommentAuthorDto,
+  ResponseCommentDto,
+  ResponseCommentListDto,
+} from '../dtos/response-comment.dto';
 import { Comment } from '../entities/comment.entity';
 
 export class CommentMapper {
@@ -17,6 +21,18 @@ export class CommentMapper {
     return {
       id: user.id,
       nickname: user.nickname,
+    };
+  }
+
+  static toCommentListDto(
+    comments: Comment[],
+    nextCursor: number | null,
+    hasNext: boolean,
+  ): ResponseCommentListDto {
+    return {
+      items: comments.map((comment) => this.toCommentDetailDto(comment)),
+      nextCursor,
+      hasNext,
     };
   }
 }

--- a/src/comments/mappers/comment.mapper.ts
+++ b/src/comments/mappers/comment.mapper.ts
@@ -1,0 +1,22 @@
+import { User } from 'src/users/entities/user.entity';
+import { CommentAuthorDto, ResponseCommentDto } from '../dtos/response-comment.dto';
+import { Comment } from '../entities/comment.entity';
+
+export class CommentMapper {
+  static toCommentDetailDto(comment: Comment): ResponseCommentDto {
+    return {
+      id: comment.id,
+      content: comment.content,
+      createdAt: comment.createdAt,
+      likeCount: comment.likeCount,
+      user: comment.isAnonymous ? null : this.toAuthorDto(comment.user),
+    };
+  }
+
+  static toAuthorDto(user: User): CommentAuthorDto {
+    return {
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+}

--- a/src/comments/types/comment.type.ts
+++ b/src/comments/types/comment.type.ts
@@ -1,0 +1,7 @@
+import { Comment } from '../entities/comment.entity';
+
+export type FindCommentsResult = {
+  items: Comment[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -251,6 +251,7 @@ export class PostController {
   @ApiForbiddenResponse({
     description: '다른 작성자의 댓글을 삭제하려는 경우',
   })
+  @ApiInternalServerErrorResponse({ description: '댓글 삭제 처리에 실패한 경우' })
   @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async deleteComment(
     @Param('postId', ParseIntPipe) postId: number,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -43,8 +43,9 @@ import { CreateCommentDto } from 'src/comments/dtos/create-comment.dto';
 import { PostMapper } from './mappers/post-mapper';
 import { PostLikeMapper } from './mappers/post-like.mapper';
 import { CommentMapper } from 'src/comments/mappers/comment.mapper';
-import { ResponseCommentDto } from 'src/comments/dtos/response-comment.dto';
+import { ResponseCommentDto, ResponseCommentListDto } from 'src/comments/dtos/response-comment.dto';
 import { UpdateCommentDto } from 'src/comments/dtos/update-comment.dto';
+import { FindCommentsQueryDto } from 'src/comments/dtos/find-comments-query.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -256,5 +257,22 @@ export class PostController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<void> {
     return await this.commentService.deleteComment(postId, commentId, user.userId);
+  }
+
+  @Get(':id/comments')
+  @ApiOperation({ summary: '게시글 댓글 목록 조회' })
+  @ApiOkResponse({ type: ResponseCommentListDto })
+  @ApiNotFoundResponse({ description: '존재하지 않는 게시글의 댓글을 조회하려는 경우' })
+  @ApiBadRequestResponse({ description: '조회 조건이 올바르지 않은 경우' })
+  async findCommentsByPostId(
+    @Param('id', ParseIntPipe) postId: number,
+    @Query() findCommentsQueryDto: FindCommentsQueryDto,
+  ): Promise<ResponseCommentListDto> {
+    const { items, nextCursor, hasNext } = await this.commentService.findCommentsByPostId(
+      postId,
+      findCommentsQueryDto,
+    );
+
+    return CommentMapper.toCommentListDto(items, nextCursor, hasNext);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,3 +1,4 @@
+import { CommentService } from './../comments/comments.service';
 import {
   Body,
   Controller,
@@ -38,12 +39,16 @@ import {
 import { FindPostsQueryDto } from './dtos/find-posts-query.dto';
 import { UpdatePostDto } from './dtos/update-post.dto';
 import { ResponsePostLikeDto } from './dtos/response-post-like.dto';
+import { CreateCommentDto } from 'src/comments/dtos/create-comment.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
 @Controller('posts')
 export class PostController {
-  constructor(private readonly postService: PostService) {}
+  constructor(
+    private readonly postService: PostService,
+    private readonly commentService: CommentService,
+  ) {}
 
   @Authenticated()
   @Post()
@@ -152,5 +157,16 @@ export class PostController {
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<ResponsePostLikeDto> {
     return await this.postService.deletePostLike(postId, user.userId);
+  }
+
+  // 댓글 엔드포인트
+  @Post(':id/comments')
+  @Authenticated()
+  async createComment(
+    @Body() createCommentDto: CreateCommentDto,
+    @Param('id', ParseIntPipe) postId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return await this.commentService.createComment(createCommentDto, postId, user.userId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -18,6 +18,7 @@ import {
   ApiCreatedResponse,
   ApiExtraModels,
   ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -193,6 +194,8 @@ export class PostController {
   @ApiNotFoundResponse({
     description: '존재하지 않는 게시글에 댓글을 작성하려는 경우',
   })
+  @ApiInternalServerErrorResponse({ description: '생성된 댓글 조회에 실패한 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async createComment(
     @Body() createCommentDto: CreateCommentDto,
     @Param('id', ParseIntPipe) postId: number,
@@ -217,6 +220,7 @@ export class PostController {
   @ApiForbiddenResponse({
     description: '다른 작성자의 댓글을 수정하려는 경우',
   })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async editComment(
     @Body() updateCommentDto: UpdateCommentDto,
     @Param('postId', ParseIntPipe) postId: number,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -42,6 +42,8 @@ import { ResponsePostLikeDto } from './dtos/response-post-like.dto';
 import { CreateCommentDto } from 'src/comments/dtos/create-comment.dto';
 import { PostMapper } from './mappers/post-mapper';
 import { PostLikeMapper } from './mappers/post-like.mapper';
+import { CommentMapper } from 'src/comments/mappers/comment.mapper';
+import { ResponseCommentDto } from 'src/comments/dtos/response-comment.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -185,11 +187,22 @@ export class PostController {
   // 댓글 엔드포인트
   @Post(':id/comments')
   @Authenticated()
+  @ApiOperation({ summary: '게시글 댓글 작성' })
+  @ApiCreatedResponse({ type: ResponseCommentDto, description: '댓글 작성 성공' })
+  @ApiNotFoundResponse({
+    description: '존재하지 않는 게시글에 댓글을 작성하려는 경우',
+  })
   async createComment(
     @Body() createCommentDto: CreateCommentDto,
     @Param('id', ParseIntPipe) postId: number,
     @CurrentUser() user: AuthenticatedUser,
-  ) {
-    return await this.commentService.createComment(createCommentDto, postId, user.userId);
+  ): Promise<ResponseCommentDto> {
+    const createdComment = await this.commentService.createComment(
+      createCommentDto,
+      postId,
+      user.userId,
+    );
+
+    return CommentMapper.toCommentDetailDto(createdComment);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -193,6 +193,7 @@ export class PostController {
   @ApiNotFoundResponse({
     description: '존재하지 않는 게시글에 댓글을 작성하려는 경우',
   })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async createComment(
     @Body() createCommentDto: CreateCommentDto,
     @Param('id', ParseIntPipe) postId: number,
@@ -217,6 +218,7 @@ export class PostController {
   @ApiForbiddenResponse({
     description: '다른 작성자의 댓글을 수정하려는 경우',
   })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
   async editComment(
     @Body() updateCommentDto: UpdateCommentDto,
     @Param('postId', ParseIntPipe) postId: number,
@@ -234,5 +236,25 @@ export class PostController {
     );
 
     return CommentMapper.toCommentDetailDto(updatedComment);
+  }
+
+  @Delete(':postId/comments/:commentId')
+  @HttpCode(204)
+  @Authenticated()
+  @ApiOperation({ summary: '게시글 댓글 삭제' })
+  @ApiNoContentResponse({ description: '댓글 삭제 성공' })
+  @ApiNotFoundResponse({
+    description: '삭제된 게시글의 댓글을 삭제하거나 존재하지 않는 댓글을 삭제하려는 경우',
+  })
+  @ApiForbiddenResponse({
+    description: '다른 작성자의 댓글을 삭제하려는 경우',
+  })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  async deleteComment(
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<void> {
+    return await this.commentService.deleteComment(postId, commentId, user.userId);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -44,6 +44,7 @@ import { PostMapper } from './mappers/post-mapper';
 import { PostLikeMapper } from './mappers/post-like.mapper';
 import { CommentMapper } from 'src/comments/mappers/comment.mapper';
 import { ResponseCommentDto } from 'src/comments/dtos/response-comment.dto';
+import { UpdateCommentDto } from 'src/comments/dtos/update-comment.dto';
 
 @ApiTags('Post')
 @ApiExtraModels(ResponsePostDetailDto, ResponsePostListDto, ResponsePostListItemDto)
@@ -204,5 +205,34 @@ export class PostController {
     );
 
     return CommentMapper.toCommentDetailDto(createdComment);
+  }
+
+  @Patch(':postId/comments/:commentId')
+  @Authenticated()
+  @ApiOperation({ summary: '게시글 댓글 수정' })
+  @ApiOkResponse({ type: ResponseCommentDto, description: '댓글 수정 성공' })
+  @ApiNotFoundResponse({
+    description: '삭제된 게시글의 댓글을 수정하거나 존재하지 않는 댓글을 수정하려는 경우',
+  })
+  @ApiForbiddenResponse({
+    description: '다른 작성자의 댓글을 수정하려는 경우',
+  })
+  async editComment(
+    @Body() updateCommentDto: UpdateCommentDto,
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    if (Object.keys(updateCommentDto).length < 1)
+      throw new BadRequestException('수정할 값이 없습니다.');
+
+    const updatedComment = await this.commentService.editComment(
+      updateCommentDto,
+      postId,
+      commentId,
+      user.userId,
+    );
+
+    return CommentMapper.toCommentDetailDto(updatedComment);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -8,10 +8,12 @@ import { PostRepository } from './posts.repository';
 import { PostCategoryModule } from 'src/post-categories/post-categories.module';
 import { PostLikeService } from './post-like.service';
 import { PostLikeRepository } from './post-like.repository';
+import { CommentModule } from 'src/comments/comments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule],
+  imports: [TypeOrmModule.forFeature([Post, PostLike]), PostCategoryModule, CommentModule],
   controllers: [PostController],
   providers: [PostService, PostRepository, PostLikeService, PostLikeRepository],
+  exports: [PostService, PostRepository],
 })
 export class PostModule {}

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -83,4 +83,8 @@ export class PostRepository {
   async increaseViewCount(postId: number): Promise<UpdateResult> {
     return await this.postRepository.increment({ id: postId }, 'viewCount', 1);
   }
+
+  async increaseCommentCount(postId: number, manager: EntityManager): Promise<UpdateResult> {
+    return await manager.increment(Post, { id: postId }, 'commentCount', 1);
+  }
 }

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -87,4 +87,8 @@ export class PostRepository {
   async increaseCommentCount(postId: number, manager: EntityManager): Promise<UpdateResult> {
     return await manager.increment(Post, { id: postId }, 'commentCount', 1);
   }
+
+  async decreaseCommentCount(postId: number, manager: EntityManager): Promise<UpdateResult> {
+    return await manager.decrement(Post, { id: postId }, 'commentCount', 1);
+  }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -131,24 +131,6 @@ export class PostService {
     return existingPost.viewCount + 1;
   }
 
-  private validatePostAuthor(currentUserId: number, authorId: number): void {
-    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
-  }
-
-  async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
-    const post = await this.postRepository.findPostById(postId, manager);
-
-    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
-
-    return post;
-  }
-
-  private async increasePostViewCount(postId: number): Promise<void> {
-    await this.findPostByIdOrThrow(postId);
-
-    await this.postRepository.increaseViewCount(postId);
-  }
-
   private buildUpdatePostPayload(updatePostDto: UpdatePostDto): UpdatePostPayloadDto {
     const { categoryId, ...updatePostData } = updatePostDto;
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -135,6 +135,24 @@ export class PostService {
     return PostLikeMapper.toPostLikeDto(post, false);
   }
 
+  private validatePostAuthor(currentUserId: number, authorId: number): void {
+    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
+  }
+
+  async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
+    const post = await this.postRepository.findPostById(postId, manager);
+
+    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
+
+    return post;
+  }
+
+  private async increasePostViewCount(postId: number): Promise<void> {
+    await this.findPostByIdOrThrow(postId);
+
+    await this.postRepository.increaseViewCount(postId);
+  }
+
   private buildUpdatePostPayload(updatePostDto: UpdatePostDto): UpdatePostPayloadDto {
     const { categoryId, ...updatePostData } = updatePostDto;
 
@@ -164,23 +182,5 @@ export class PostService {
 
     if (updatePostDto.categoryId !== undefined)
       await this.postCategoryService.findPostCategoryById(updatePostDto.categoryId);
-  }
-
-  validatePostAuthor(currentUserId: number, authorId: number): void {
-    if (authorId !== currentUserId) throw new ForbiddenException('게시글에 대한 권한이 없습니다.');
-  }
-
-  private async findPostByIdOrThrow(postId: number, manager?: EntityManager): Promise<Post> {
-    const post = await this.postRepository.findPostById(postId, manager);
-
-    if (!post) throw new NotFoundException('존재하지 않는 게시글입니다.');
-
-    return post;
-  }
-
-  private async increasePostViewCount(postId: number): Promise<void> {
-    await this.findPostByIdOrThrow(postId);
-
-    await this.postRepository.increaseViewCount(postId);
   }
 }

--- a/test/comments-create.e2e-spec.ts
+++ b/test/comments-create.e2e-spec.ts
@@ -1,0 +1,193 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { CommentLike } from '../src/comments/entities/comment-like.entity';
+import { Comment } from '../src/comments/entities/comment.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { Post } from '../src/posts/entities/post.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Comments Create (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(CommentLike).execute();
+    await dataSource.createQueryBuilder().delete().from(Comment).execute();
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPost(
+    userId: number,
+    categoryId: number,
+    overrides?: Partial<Pick<Post, 'title' | 'content' | 'isAnonymous'>>,
+  ): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: overrides?.title ?? '댓글 테스트용 게시글',
+      content: overrides?.content ?? '댓글이 달릴 게시글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      user: { id: userId },
+      category: { id: categoryId },
+    });
+  }
+
+  it('POST /posts/:id/comments 댓글 작성 성공', async () => {
+    const signupResponse = await signupUser('commenter@example.com', 'commenter');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '저도 같은 생각입니다.',
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toEqual(expect.any(Number));
+    expect(response.body.content).toBe('저도 같은 생각입니다.');
+    expect(response.body.likeCount).toBe(0);
+    expect(response.body.user).toEqual({
+      id: signupResponse.body.user.id,
+      nickname: 'commenter',
+    });
+    expect(response.body.createdAt).toEqual(expect.any(String));
+
+    const createdComment = await dataSource.getRepository(Comment).findOne({
+      where: { id: response.body.id },
+      relations: {
+        user: true,
+        post: true,
+      },
+    });
+
+    expect(createdComment).toBeDefined();
+    expect(createdComment?.content).toBe('저도 같은 생각입니다.');
+    expect(createdComment?.likeCount).toBe(0);
+    expect(createdComment?.isAnonymous).toBe(false);
+    expect(createdComment?.user.id).toBe(signupResponse.body.user.id);
+    expect(createdComment?.post.id).toBe(post.id);
+
+    const updatedPost = await dataSource.getRepository(Post).findOneBy({ id: post.id });
+    expect(updatedPost?.commentCount).toBe(1);
+  });
+
+  it('POST /posts/:id/comments 익명 댓글 작성 성공 시 user는 null', async () => {
+    const signupResponse = await signupUser('anonymous-commenter@example.com', 'anon-commenter');
+    const category = await createCategory('질문');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '익명으로 남기는 댓글입니다.',
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.user).toBeNull();
+  });
+
+  it('POST /posts/:id/comments 존재하지 않는 게시글이면 실패', async () => {
+    const signupResponse = await signupUser('missing-post@example.com', 'missing-post');
+
+    const response = await request(httpApp())
+      .post('/posts/999/comments')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '없는 게시글에 다는 댓글',
+        isAnonymous: false,
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
+  });
+
+  it('POST /posts/:id/comments 잘못된 요청값이면 실패', async () => {
+    const signupResponse = await signupUser('invalid-comment@example.com', 'invalid-comment');
+    const category = await createCategory('정보');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .post(`/posts/${post.id}/comments`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining([
+        'content should not be empty',
+        'isAnonymous should not be empty',
+        'isAnonymous must be a boolean value',
+      ]),
+    );
+
+    const comments = await dataSource.getRepository(Comment).find();
+    expect(comments).toHaveLength(0);
+
+    const unchangedPost = await dataSource.getRepository(Post).findOneBy({ id: post.id });
+    expect(unchangedPost?.commentCount).toBe(0);
+  });
+
+  it('POST /posts/:id/comments 인증 없이 요청하면 실패', async () => {
+    const signupResponse = await signupUser('post-owner@example.com', 'post-owner');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp()).post(`/posts/${post.id}/comments`).send({
+      content: '로그인 없이 작성하는 댓글',
+      isAnonymous: false,
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
+  });
+});

--- a/test/comments-delete.e2e-spec.ts
+++ b/test/comments-delete.e2e-spec.ts
@@ -1,0 +1,182 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { CommentLike } from '../src/comments/entities/comment-like.entity';
+import { Comment } from '../src/comments/entities/comment.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { Post } from '../src/posts/entities/post.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Comments Delete (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(CommentLike).execute();
+    await dataSource.createQueryBuilder().delete().from(Comment).execute();
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPost(
+    userId: number,
+    categoryId: number,
+    overrides?: Partial<Pick<Post, 'title' | 'content' | 'isAnonymous' | 'commentCount'>>,
+  ): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: overrides?.title ?? '댓글 삭제 테스트용 게시글',
+      content: overrides?.content ?? '댓글 삭제가 일어날 게시글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      commentCount: overrides?.commentCount ?? 0,
+      user: { id: userId },
+      category: { id: categoryId },
+    });
+  }
+
+  async function createComment(
+    postId: number,
+    userId: number,
+    overrides?: Partial<Pick<Comment, 'content' | 'isAnonymous'>>,
+  ): Promise<Comment> {
+    return await dataSource.getRepository(Comment).save({
+      content: overrides?.content ?? '삭제될 댓글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      post: { id: postId },
+      user: { id: userId },
+    });
+  }
+
+  it('DELETE /posts/:postId/comments/:commentId 작성자가 댓글을 삭제한다', async () => {
+    const signupResponse = await signupUser('comment-delete@example.com', 'comment-delete');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id, { commentCount: 1 });
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .delete(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+
+    const deletedComment = await dataSource.getRepository(Comment).findOneBy({
+      id: comment.id,
+    });
+    const deletedCommentWithDeleted = await dataSource.getRepository(Comment).findOne({
+      where: { id: comment.id },
+      withDeleted: true,
+    });
+    const updatedPost = await dataSource.getRepository(Post).findOneBy({ id: post.id });
+
+    expect(deletedComment).toBeNull();
+    expect(deletedCommentWithDeleted).toBeDefined();
+    expect(deletedCommentWithDeleted?.id).toBe(comment.id);
+    expect(updatedPost?.commentCount).toBe(0);
+  });
+
+  it('DELETE /posts/:postId/comments/:commentId 작성자가 아니면 삭제에 실패한다', async () => {
+    const writerSignup = await signupUser('comment-delete-owner@example.com', 'delete-owner');
+    const otherSignup = await signupUser('comment-delete-other@example.com', 'delete-other');
+    const category = await createCategory('자유');
+    const post = await createPost(writerSignup.body.user.id, category.id, { commentCount: 1 });
+    const comment = await createComment(post.id, writerSignup.body.user.id);
+
+    const response = await request(httpApp())
+      .delete(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${otherSignup.body.accessToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 403,
+      message: '댓글을 삭제할 권한이 없습니다.',
+    });
+  });
+
+  it('DELETE /posts/:postId/comments/:commentId 존재하지 않는 댓글이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-delete-no-comment@example.com', 'no-comment');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .delete(`/posts/${post.id}/comments/999`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 댓글입니다.',
+    });
+  });
+
+  it('DELETE /posts/:postId/comments/:commentId 다른 게시글의 댓글이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-delete-wrong-post@example.com', 'wrong-post');
+    const category = await createCategory('자유');
+    const firstPost = await createPost(signupResponse.body.user.id, category.id, {
+      commentCount: 1,
+    });
+    const secondPost = await createPost(signupResponse.body.user.id, category.id);
+    const comment = await createComment(firstPost.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .delete(`/posts/${secondPost.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 댓글입니다.',
+    });
+  });
+
+  it('DELETE /posts/:postId/comments/:commentId 인증 없이 삭제하면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-delete-auth-owner@example.com', 'auth-owner');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id, { commentCount: 1 });
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp()).delete(`/posts/${post.id}/comments/${comment.id}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
+  });
+});

--- a/test/comments-read.e2e-spec.ts
+++ b/test/comments-read.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { CommentLike } from '../src/comments/entities/comment-like.entity';
+import { Comment } from '../src/comments/entities/comment.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { Post } from '../src/posts/entities/post.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Comments Read (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(CommentLike).execute();
+    await dataSource.createQueryBuilder().delete().from(Comment).execute();
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPost(
+    userId: number,
+    categoryId: number,
+    overrides?: Partial<Pick<Post, 'title' | 'content' | 'isAnonymous'>>,
+  ): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: overrides?.title ?? '댓글 목록 테스트용 게시글',
+      content: overrides?.content ?? '댓글 목록이 달릴 게시글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      user: { id: userId },
+      category: { id: categoryId },
+    });
+  }
+
+  async function createComment(
+    postId: number,
+    userId: number,
+    overrides?: Partial<Pick<Comment, 'content' | 'isAnonymous'>>,
+  ): Promise<Comment> {
+    return await dataSource.getRepository(Comment).save({
+      content: overrides?.content ?? '댓글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      post: { id: postId },
+      user: { id: userId },
+    });
+  }
+
+  it('GET /posts/:id/comments 게시글 댓글 목록 조회 성공', async () => {
+    const signupResponse = await signupUser('comment-read@example.com', 'comment-reader');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const firstComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '첫 번째 댓글',
+    });
+    const secondComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '두 번째 댓글',
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}/comments`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0]).toMatchObject({
+      id: firstComment.id,
+      content: '첫 번째 댓글',
+      user: {
+        id: signupResponse.body.user.id,
+        nickname: 'comment-reader',
+      },
+    });
+    expect(response.body.items[1]).toMatchObject({
+      id: secondComment.id,
+      content: '두 번째 댓글',
+    });
+    expect(response.body.nextCursor).toBeNull();
+    expect(response.body.hasNext).toBe(false);
+  });
+
+  it('GET /posts/:id/comments cursor 기반 페이지네이션 조회 성공', async () => {
+    const signupResponse = await signupUser('comment-page@example.com', 'comment-page');
+    const category = await createCategory('정보');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const firstComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '첫 번째 댓글',
+    });
+    const secondComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '두 번째 댓글',
+    });
+    const thirdComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '세 번째 댓글',
+    });
+
+    const response = await request(httpApp()).get(
+      `/posts/${post.id}/comments?cursor=${firstComment.id}&limit=2`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0].id).toBe(secondComment.id);
+    expect(response.body.items[1].id).toBe(thirdComment.id);
+    expect(response.body.nextCursor).toBeNull();
+    expect(response.body.hasNext).toBe(false);
+  });
+
+  it('GET /posts/:id/comments 익명 댓글은 작성자 정보를 숨긴다', async () => {
+    const signupResponse = await signupUser('comment-anon@example.com', 'anon-reader');
+    const category = await createCategory('질문');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    await createComment(post.id, signupResponse.body.user.id, {
+      content: '익명 댓글입니다.',
+      isAnonymous: true,
+    });
+
+    const response = await request(httpApp()).get(`/posts/${post.id}/comments`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.items[0].user).toBeNull();
+  });
+
+  it('GET /posts/:id/comments soft delete된 댓글은 목록에서 제외된다', async () => {
+    const signupResponse = await signupUser('comment-deleted@example.com', 'deleted-reader');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const activeComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '보이는 댓글',
+    });
+    const deletedComment = await createComment(post.id, signupResponse.body.user.id, {
+      content: '삭제된 댓글',
+    });
+
+    await dataSource.getRepository(Comment).softDelete(deletedComment.id);
+
+    const response = await request(httpApp()).get(`/posts/${post.id}/comments`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].id).toBe(activeComment.id);
+  });
+
+  it('GET /posts/:id/comments 존재하지 않는 게시글이면 실패', async () => {
+    const response = await request(httpApp()).get('/posts/999/comments');
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
+  });
+
+  it('GET /posts/:id/comments 잘못된 조회 조건이면 실패', async () => {
+    const signupResponse = await signupUser('comment-invalid-query@example.com', 'invalid-query');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp()).get(`/posts/${post.id}/comments?cursor=0&limit=51`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining([
+        'cursor must not be less than 1',
+        'limit must not be greater than 50',
+      ]),
+    );
+  });
+});

--- a/test/comments-update.e2e-spec.ts
+++ b/test/comments-update.e2e-spec.ts
@@ -1,0 +1,259 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types';
+import { CommentLike } from '../src/comments/entities/comment-like.entity';
+import { Comment } from '../src/comments/entities/comment.entity';
+import { PostCategory } from '../src/post-categories/entities/post-category.entity';
+import { Post } from '../src/posts/entities/post.entity';
+import { User } from '../src/users/entities/user.entity';
+import { createAuthUserTestApp } from './test-app';
+
+jest.setTimeout(30000);
+
+describe('Comments Update (e2e)', () => {
+  let app: INestApplication<App>;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    app = (await createAuthUserTestApp()) as INestApplication<App>;
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.createQueryBuilder().delete().from(CommentLike).execute();
+    await dataSource.createQueryBuilder().delete().from(Comment).execute();
+    await dataSource.createQueryBuilder().delete().from(Post).execute();
+    await dataSource.createQueryBuilder().delete().from(PostCategory).execute();
+    await dataSource.createQueryBuilder().delete().from(User).execute();
+  });
+
+  function httpApp(): App {
+    return app.getHttpServer();
+  }
+
+  async function signupUser(email: string, nickname: string): Promise<Response> {
+    return request(httpApp()).post('/auth/signup').send({
+      email,
+      password: '1q2w3e4r',
+      birthDate: '2000-01-01',
+      gender: 'MALE',
+      nickname,
+      schoolInfo: '인덕대학교',
+    });
+  }
+
+  async function createCategory(name: string): Promise<PostCategory> {
+    return await dataSource.getRepository(PostCategory).save({ name });
+  }
+
+  async function createPost(
+    userId: number,
+    categoryId: number,
+    overrides?: Partial<Pick<Post, 'title' | 'content' | 'isAnonymous'>>,
+  ): Promise<Post> {
+    return await dataSource.getRepository(Post).save({
+      title: overrides?.title ?? '댓글 수정 테스트용 게시글',
+      content: overrides?.content ?? '댓글 수정이 일어날 게시글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      user: { id: userId },
+      category: { id: categoryId },
+    });
+  }
+
+  async function createComment(
+    postId: number,
+    userId: number,
+    overrides?: Partial<Pick<Comment, 'content' | 'isAnonymous'>>,
+  ): Promise<Comment> {
+    return await dataSource.getRepository(Comment).save({
+      content: overrides?.content ?? '수정 전 댓글입니다.',
+      isAnonymous: overrides?.isAnonymous ?? false,
+      post: { id: postId },
+      user: { id: userId },
+    });
+  }
+
+  it('PATCH /posts/:postId/comments/:commentId 작성자가 댓글을 수정한다', async () => {
+    const signupResponse = await signupUser('comment-update@example.com', 'comment-writer');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '수정 후 댓글입니다.',
+        isAnonymous: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(comment.id);
+    expect(response.body.content).toBe('수정 후 댓글입니다.');
+    expect(response.body.user).toBeNull();
+    expect(response.body.likeCount).toBe(0);
+    expect(response.body.createdAt).toEqual(expect.any(String));
+
+    const updatedComment = await dataSource.getRepository(Comment).findOne({
+      where: { id: comment.id },
+      relations: {
+        user: true,
+        post: true,
+      },
+    });
+
+    expect(updatedComment?.content).toBe('수정 후 댓글입니다.');
+    expect(updatedComment?.isAnonymous).toBe(true);
+    expect(updatedComment?.user.id).toBe(signupResponse.body.user.id);
+    expect(updatedComment?.post.id).toBe(post.id);
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 작성자가 아니면 수정에 실패한다', async () => {
+    const writerSignup = await signupUser('comment-owner@example.com', 'comment-owner');
+    const otherSignup = await signupUser('comment-other@example.com', 'comment-other');
+    const category = await createCategory('자유');
+    const post = await createPost(writerSignup.body.user.id, category.id);
+    const comment = await createComment(post.id, writerSignup.body.user.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${otherSignup.body.accessToken}`)
+      .send({
+        content: '권한 없는 수정',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 403,
+      message: '댓글을 수정할 권한이 없습니다.',
+    });
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 잘못된 수정값이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-invalid@example.com', 'comment-invalid');
+    const category = await createCategory('정보');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: 'a'.repeat(501),
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.statusCode).toBe(400);
+    expect(response.body.error.message).toEqual(
+      expect.arrayContaining(['content must be shorter than or equal to 500 characters']),
+    );
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 수정할 값이 없으면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-empty@example.com', 'comment-empty');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 400,
+      message: '수정할 값이 없습니다.',
+    });
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 존재하지 않는 게시글이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-no-post@example.com', 'comment-no-post');
+
+    const response = await request(httpApp())
+      .patch('/posts/999/comments/1')
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '없는 게시글의 댓글 수정',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 게시글입니다.',
+    });
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 존재하지 않는 댓글이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-no-comment@example.com', 'comment-no-comment');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/999`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '없는 댓글 수정',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 댓글입니다.',
+    });
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 다른 게시글의 댓글이면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-wrong-post@example.com', 'wrong-post');
+    const category = await createCategory('자유');
+    const firstPost = await createPost(signupResponse.body.user.id, category.id, {
+      title: '첫 번째 게시글',
+    });
+    const secondPost = await createPost(signupResponse.body.user.id, category.id, {
+      title: '두 번째 게시글',
+    });
+    const comment = await createComment(firstPost.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp())
+      .patch(`/posts/${secondPost.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${signupResponse.body.accessToken}`)
+      .send({
+        content: '다른 게시글 경로로 수정 시도',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 404,
+      message: '존재하지 않는 댓글입니다.',
+    });
+  });
+
+  it('PATCH /posts/:postId/comments/:commentId 인증 없이 수정하면 실패한다', async () => {
+    const signupResponse = await signupUser('comment-auth-owner@example.com', 'auth-commenter');
+    const category = await createCategory('자유');
+    const post = await createPost(signupResponse.body.user.id, category.id);
+    const comment = await createComment(post.id, signupResponse.body.user.id);
+
+    const response = await request(httpApp()).patch(`/posts/${post.id}/comments/${comment.id}`).send({
+      content: '로그인 없이 수정',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    });
+  });
+});

--- a/test/comments-update.e2e-spec.ts
+++ b/test/comments-update.e2e-spec.ts
@@ -245,9 +245,11 @@ describe('Comments Update (e2e)', () => {
     const post = await createPost(signupResponse.body.user.id, category.id);
     const comment = await createComment(post.id, signupResponse.body.user.id);
 
-    const response = await request(httpApp()).patch(`/posts/${post.id}/comments/${comment.id}`).send({
-      content: '로그인 없이 수정',
-    });
+    const response = await request(httpApp())
+      .patch(`/posts/${post.id}/comments/${comment.id}`)
+      .send({
+        content: '로그인 없이 수정',
+      });
 
     expect(response.status).toBe(401);
     expect(response.body.success).toBe(false);


### PR DESCRIPTION
## 연관된 이슈

- #138 

## 📝 작업 내용

- [x] `GET /posts/:postId/comments` 댓글 목록 조회 API 구현
- [x] `CommentController`에 댓글 목록 조회 엔드포인트 추가
- [x] 댓글 목록 요청 및 응답 DTO 정의
- [x] 댓글 목록 조회 Swagger 문서화 추가
- [x] 게시글이 존재하는지 검증 추가
- [x] cursor pagination 적용
- [x] 익명 댓글일 경우 user는 null로 반환
- [x] `CommentMapper` 목록 매핑 추가
- [x] 댓글 목록 조회 단위 테스트 추가
- [x] 댓글 목록 조회 e2e 테스트 추가
