### PR TITLE
Docker, Nginx에 certbot 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,13 @@ services:
       - ./nginx/conf.d:/etc/nginx/conf.d
       - ./certbot/www:/var/www/certbot
       - ./certbot/conf:/etc/letsencrypt
+    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
+
+  certbot:
+    container_name: certbot
+    image: certbot/certbot:latest
+    restart: unless-stopped
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $!; done;'"

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -2,6 +2,10 @@ server {
     listen 80;
     server_name api.lunchmate.co.kr localhost;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location / {
         proxy_pass http://lunchmate-backend:3000;
 


### PR DESCRIPTION
## 연관된 이슈

- #154

## 📝 작업 내용

- [x] docker-compose 파일에 Certbot 컨테이너 구성
- [x] certbot이 발급한 challenge파일을 nginx가 서빙할 수 있도록 파일 수정
