### PR TITLE
User role 속성 추가 및 권한 검증 데코레이터 구현

### DIFF
--- a/migrations/1779871254359-AddRoleToUser.ts
+++ b/migrations/1779871254359-AddRoleToUser.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRoleToUser1779871254359 implements MigrationInterface {
+    name = 'AddRoleToUser1779871254359'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."users_role_enum" AS ENUM('ADMIN', 'USER')`);
+        await queryRunner.query(`ALTER TABLE "users" ADD "role" "public"."users_role_enum" NOT NULL DEFAULT 'USER'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "role"`);
+        await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+    }
+
+}

--- a/src/auth/auth.constants.ts
+++ b/src/auth/auth.constants.ts
@@ -10,4 +10,7 @@ export const AUTH_ERROR_MESSAGES = {
   invalidAccessToken: 'Access token is invalid.',
   invalidRefreshToken: 'Refresh token is invalid.',
   invaludTokenFormat: 'Token 포맷이 잘못되었습니다.',
+  accessDenied: 'You do not have permission to access',
 } as const;
+
+export const ROLES_KEY = 'roles';

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { UserService } from '../users/users.service';
-import { User } from '../users/entities/user.entity';
+import { User, UserRole } from '../users/entities/user.entity';
 import { AUTH_ERROR_MESSAGES, JWT_DEFAULTS } from './auth.constants';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
@@ -46,6 +46,7 @@ export class AuthService {
       user.id,
       user.email,
       user.nickname,
+      user.role,
       user.tokenVersion ?? 0,
     );
 
@@ -57,7 +58,13 @@ export class AuthService {
 
   async login(loginDto: LoginDto): Promise<AuthResult> {
     const user = await this.validateCredentials(loginDto);
-    const tokens = await this.issueTokens(user.id, user.email, user.nickname, user.tokenVersion);
+    const tokens = await this.issueTokens(
+      user.id,
+      user.email,
+      user.nickname,
+      user.role,
+      user.tokenVersion,
+    );
 
     return {
       ...tokens,
@@ -90,6 +97,7 @@ export class AuthService {
       user.id,
       user.email,
       user.nickname,
+      user.role,
       user.tokenVersion,
     );
 
@@ -135,9 +143,16 @@ export class AuthService {
     userId: number,
     email: string,
     nickname: string,
+    role: UserRole,
     tokenVersion: number,
   ): Promise<AuthTokensResult> {
-    const tokens = await this.issueTokensWithoutPersisting(userId, email, nickname, tokenVersion);
+    const tokens = await this.issueTokensWithoutPersisting(
+      userId,
+      email,
+      nickname,
+      role,
+      tokenVersion,
+    );
     const refreshTokenHash = await this.createRefreshTokenHash(tokens.refreshToken);
     await this.userService.updateRefreshTokenHash(userId, refreshTokenHash);
 
@@ -148,18 +163,19 @@ export class AuthService {
     userId: number,
     email: string,
     nickname: string,
+    role: UserRole,
     tokenVersion: number,
   ): Promise<AuthTokensResult> {
     const accessTokenId = randomUUID();
     const refreshTokenId = randomUUID();
 
     const accessToken = await this.jwtService.signAsync(
-      this.buildAccessPayload(userId, email, nickname, tokenVersion, accessTokenId),
+      this.buildAccessPayload(userId, email, nickname, role, tokenVersion, accessTokenId),
       this.getAccessTokenOptions(),
     );
 
     const refreshToken = await this.jwtService.signAsync(
-      this.buildRefreshPayload(userId, email, nickname, tokenVersion, refreshTokenId),
+      this.buildRefreshPayload(userId, email, nickname, role, tokenVersion, refreshTokenId),
       this.getRefreshTokenOptions(),
     );
 
@@ -216,6 +232,7 @@ export class AuthService {
     userId: number,
     email: string,
     nickname: string,
+    role: UserRole,
     tokenVersion: number,
     tokenId: string,
   ): JwtAccessPayload {
@@ -223,6 +240,7 @@ export class AuthService {
       sub: userId,
       email,
       nickname,
+      role,
       tokenVersion,
       tokenId,
       type: 'access',
@@ -233,6 +251,7 @@ export class AuthService {
     userId: number,
     email: string,
     nickname: string,
+    role: UserRole,
     tokenVersion: number,
     tokenId: string,
   ): JwtRefreshPayload {
@@ -240,6 +259,7 @@ export class AuthService {
       sub: userId,
       email,
       nickname,
+      role,
       tokenVersion,
       tokenId,
       type: 'refresh',

--- a/src/auth/decorators/role.decorator.ts
+++ b/src/auth/decorators/role.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from 'src/users/entities/user.entity';
+import { ROLES_KEY } from '../auth.constants';
+
+export const Roles = (...roles: UserRole[]) => {
+  return SetMetadata(ROLES_KEY, roles);
+};

--- a/src/auth/guards/role.guard.ts
+++ b/src/auth/guards/role.guard.ts
@@ -1,0 +1,32 @@
+import { Reflector } from '@nestjs/core';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { UserRole } from 'src/users/entities/user.entity';
+import { USER_ERROR_MESSAGES } from 'src/users/user.constants';
+import { AUTH_ERROR_MESSAGES, ROLES_KEY } from '../auth.constants';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles || requiredRoles.length < 1) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user) throw new ForbiddenException(USER_ERROR_MESSAGES.userNotFound);
+
+    const hasRole = requiredRoles.includes(user.role);
+
+    if (!hasRole) throw new ForbiddenException(AUTH_ERROR_MESSAGES.accessDenied);
+
+    return true;
+  }
+}

--- a/src/auth/interfaces/jwt-payload.interface.ts
+++ b/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,7 +1,10 @@
+import { UserRole } from 'src/users/entities/user.entity';
+
 export interface JwtAccessPayload {
   sub: number;
   email: string;
   nickname: string;
+  role: UserRole;
   tokenVersion: number;
   tokenId: string;
   type: 'access';
@@ -11,6 +14,7 @@ export interface JwtRefreshPayload {
   sub: number;
   email: string;
   nickname: string;
+  role: UserRole;
   tokenVersion: number;
   tokenId: string;
   type: 'refresh';
@@ -20,4 +24,5 @@ export interface AuthenticatedUser {
   userId: number;
   email: string;
   nickname: string;
+  role: UserRole;
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -34,6 +34,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       userId: payload.sub,
       email: payload.email,
       nickname: payload.nickname,
+      role: payload.role,
     };
   }
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -9,10 +9,22 @@ import { RoomMember } from '../../rooms/entities/room-member.entity';
 import { Room } from '../../rooms/entities/room.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
+
 @Entity('users')
 export class User extends BaseTableEntity {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column({
+    type: 'enum',
+    enum: UserRole,
+    default: UserRole.USER,
+  })
+  role: UserRole;
 
   @Column({
     unique: true,


### PR DESCRIPTION
## 연관된 이슈

- #160 

## 📝 작업 내용

- [x] `UserRole` enum 추가 (`ADMIN`, `USER`)
- [x] `User` entity에 `role` 컬럼 추가
- [x] 회원가입 시 신규 사용자의 기본 role을 `USER`로 설정
- [x] JWT payload 및 인증 사용자 정보에 `role` 추가
- [x] 사용자 role 기반 권한 검증 `RolesGuard` 구현
- [x] 관리자 권한 검증용 role 데코레이터 추가
- [x] 기존 테스트 정상 동작 확인