### PR TITLE
MealMenu에 학식 구성 필드와 구성 요소 테이블 생성

### DIFF
--- a/migrations/1780290626203-CreateComponentsTableAndAddComponentsToMealMenu.ts
+++ b/migrations/1780290626203-CreateComponentsTableAndAddComponentsToMealMenu.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateComponentsTableAndAddComponentsToMealMenu1780290626203 implements MigrationInterface {
+    name = 'CreateComponentsTableAndAddComponentsToMealMenu1780290626203'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "meal_menu_components" ("id" SERIAL NOT NULL, "name" character varying(100) NOT NULL, "meal_menu_id" integer, CONSTRAINT "PK_03541d708c02cde0bef101d7bd8" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "meal_menus" ADD "meal_date" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" ADD CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e" FOREIGN KEY ("meal_menu_id") REFERENCES "meal_menus"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" DROP CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e"`);
+        await queryRunner.query(`ALTER TABLE "meal_menus" DROP COLUMN "meal_date"`);
+        await queryRunner.query(`DROP TABLE "meal_menu_components"`);
+    }
+
+}

--- a/migrations/1780292491723-CreateComponentsTableAndAddComponentsToMealMenu.ts
+++ b/migrations/1780292491723-CreateComponentsTableAndAddComponentsToMealMenu.ts
@@ -1,17 +1,15 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class CreateComponentsTableAndAddComponentsToMealMenu1780290626203 implements MigrationInterface {
-    name = 'CreateComponentsTableAndAddComponentsToMealMenu1780290626203'
+export class CreateComponentsTableAndAddComponentsToMealMenu1780292491723 implements MigrationInterface {
+    name = 'CreateComponentsTableAndAddComponentsToMealMenu1780292491723'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "meal_menu_components" ("id" SERIAL NOT NULL, "name" character varying(100) NOT NULL, "meal_menu_id" integer, CONSTRAINT "PK_03541d708c02cde0bef101d7bd8" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`ALTER TABLE "meal_menus" ADD "meal_date" date NOT NULL`);
         await queryRunner.query(`ALTER TABLE "meal_menu_components" ADD CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e" FOREIGN KEY ("meal_menu_id") REFERENCES "meal_menus"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "meal_menu_components" DROP CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e"`);
-        await queryRunner.query(`ALTER TABLE "meal_menus" DROP COLUMN "meal_date"`);
         await queryRunner.query(`DROP TABLE "meal_menu_components"`);
     }
 

--- a/migrations/1780298957662-CreateMealMenuComponentsAndMappings.ts
+++ b/migrations/1780298957662-CreateMealMenuComponentsAndMappings.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateMealMenuComponentsAndMappings1780298957662 implements MigrationInterface {
+    name = 'CreateMealMenuComponentsAndMappings1780298957662'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" DROP CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e"`);
+        await queryRunner.query(`CREATE TABLE "meal_menu_component_mappings" ("id" SERIAL NOT NULL, "meal_menu_id" integer, "meal_menu_component_id" integer, CONSTRAINT "UQ_6a785d7c12134d7a484e7d74780" UNIQUE ("meal_menu_id", "meal_menu_component_id"), CONSTRAINT "PK_eb7645a1e48e32fedc324c295ee" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" DROP COLUMN "meal_menu_id"`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_component_mappings" ADD CONSTRAINT "FK_12a72728bf6fe8e8b01784b0622" FOREIGN KEY ("meal_menu_id") REFERENCES "meal_menus"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_component_mappings" ADD CONSTRAINT "FK_7fc160941e4440e257f125c3074" FOREIGN KEY ("meal_menu_component_id") REFERENCES "meal_menu_components"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meal_menu_component_mappings" DROP CONSTRAINT "FK_7fc160941e4440e257f125c3074"`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_component_mappings" DROP CONSTRAINT "FK_12a72728bf6fe8e8b01784b0622"`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" ADD "meal_menu_id" integer`);
+        await queryRunner.query(`DROP TABLE "meal_menu_component_mappings"`);
+        await queryRunner.query(`ALTER TABLE "meal_menu_components" ADD CONSTRAINT "FK_dc3d6a83a32da0525e3bb16929e" FOREIGN KEY ("meal_menu_id") REFERENCES "meal_menus"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/meal-menus/dto/meal-menu-detail-response.dto.ts
+++ b/src/meal-menus/dto/meal-menu-detail-response.dto.ts
@@ -18,4 +18,6 @@ export class MealMenuDetailResponseDto {
   likeCount: number;
 
   dislikeCount: number;
+
+  components: string[];
 }

--- a/src/meal-menus/entities/meal-menu-component-mapping.entity.ts
+++ b/src/meal-menus/entities/meal-menu-component-mapping.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { MealMenu } from './meal-menu.entity';
+import { MealMenuComponent } from './meal-menu-component.entity';
+
+@Entity('meal_menu_component_mappings')
+@Unique(['mealMenu', 'mealMenuComponent'])
+export class MealMenuComponentMapping {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MealMenu, (mealMenu) => mealMenu.mealMenuComponentMappings, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'meal_menu_id' })
+  mealMenu: MealMenu;
+
+  @ManyToOne(
+    () => MealMenuComponent,
+    (mealMenuComponent) => mealMenuComponent.mealMenuComponentMappings,
+  )
+  @JoinColumn({ name: 'meal_menu_component_id' })
+  mealMenuComponent: MealMenuComponent;
+}

--- a/src/meal-menus/entities/meal-menu-component.entity.ts
+++ b/src/meal-menus/entities/meal-menu-component.entity.ts
@@ -1,5 +1,5 @@
-import { MealMenu } from './meal-menu.entity';
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { MealMenuComponentMapping } from './meal-menu-component-mapping.entity';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('meal_menu_components')
 export class MealMenuComponent {
@@ -11,7 +11,9 @@ export class MealMenuComponent {
   })
   name: string;
 
-  @ManyToOne(() => MealMenu, (mealMenu) => mealMenu.components)
-  @JoinColumn({ name: 'meal_menu_id' })
-  mealMenu: MealMenu;
+  @OneToMany(
+    () => MealMenuComponentMapping,
+    (mealMenuComponentMapping) => mealMenuComponentMapping.mealMenuComponent,
+  )
+  mealMenuComponentMappings: MealMenuComponentMapping[];
 }

--- a/src/meal-menus/entities/meal-menu-component.entity.ts
+++ b/src/meal-menus/entities/meal-menu-component.entity.ts
@@ -1,0 +1,17 @@
+import { MealMenu } from './meal-menu.entity';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('meal_menu_components')
+export class MealMenuComponent {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    length: 100,
+  })
+  name: string;
+
+  @ManyToOne(() => MealMenu, (mealMenu) => mealMenu.components)
+  @JoinColumn({ name: 'meal_menu_id' })
+  mealMenu: MealMenu;
+}

--- a/src/meal-menus/entities/meal-menu.entity.ts
+++ b/src/meal-menus/entities/meal-menu.entity.ts
@@ -1,6 +1,7 @@
 import { MealMenuReaction } from './meal-menu-reaction.entity';
 import { BaseTableEntity } from '../../commons/entities/base.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { MealMenuComponent } from './meal-menu-component.entity';
 
 export enum MealType {
   BREAKFAST = 'BREAKFAST',
@@ -57,4 +58,7 @@ export class MealMenu extends BaseTableEntity {
 
   @OneToMany(() => MealMenuReaction, (MealMenuReaction) => MealMenuReaction.mealMenu)
   reactions: MealMenuReaction[];
+
+  @OneToMany(() => MealMenuComponent, (mealMenuComponent) => mealMenuComponent.mealMenu)
+  components: MealMenuComponent[];
 }

--- a/src/meal-menus/entities/meal-menu.entity.ts
+++ b/src/meal-menus/entities/meal-menu.entity.ts
@@ -1,7 +1,7 @@
 import { MealMenuReaction } from './meal-menu-reaction.entity';
 import { BaseTableEntity } from '../../commons/entities/base.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { MealMenuComponent } from './meal-menu-component.entity';
+import { MealMenuComponentMapping } from './meal-menu-component-mapping.entity';
 
 export enum MealType {
   BREAKFAST = 'BREAKFAST',
@@ -59,6 +59,9 @@ export class MealMenu extends BaseTableEntity {
   @OneToMany(() => MealMenuReaction, (MealMenuReaction) => MealMenuReaction.mealMenu)
   reactions: MealMenuReaction[];
 
-  @OneToMany(() => MealMenuComponent, (mealMenuComponent) => mealMenuComponent.mealMenu)
-  components: MealMenuComponent[];
+  @OneToMany(
+    () => MealMenuComponentMapping,
+    (mealMenuComponentMapping) => mealMenuComponentMapping.mealMenu,
+  )
+  mealMenuComponentMappings: MealMenuComponentMapping[];
 }

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -21,7 +21,6 @@ import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.d
 import { ActionType } from './entities/meal-menu-reaction.entity';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenusService } from './meal-menus.service';
-import { MealMenuComponent } from './entities/meal-menu-component.entity';
 
 @ApiTags('MealMenu')
 @Controller('meal-menus')
@@ -109,7 +108,9 @@ export class MealMenusController {
       calorie: mealMenu.calorie ?? null,
       likeCount: mealMenu.likeCount,
       dislikeCount: mealMenu.dislikeCount,
-      components: mealMenu.components.map((component) => component.name),
+      components: mealMenu.mealMenuComponentMappings.map(
+        (mapping) => mapping.mealMenuComponent.name,
+      ),
     };
   }
 

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -21,6 +21,7 @@ import { MealMenuReactionResponseDto } from './dto/meal-menu-reaction-response.d
 import { ActionType } from './entities/meal-menu-reaction.entity';
 import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenusService } from './meal-menus.service';
+import { MealMenuComponent } from './entities/meal-menu-component.entity';
 
 @ApiTags('MealMenu')
 @Controller('meal-menus')
@@ -108,6 +109,7 @@ export class MealMenusController {
       calorie: mealMenu.calorie ?? null,
       likeCount: mealMenu.likeCount,
       dislikeCount: mealMenu.dislikeCount,
+      components: mealMenu.components.map((component) => component.name),
     };
   }
 

--- a/src/meal-menus/meal-menus.module.ts
+++ b/src/meal-menus/meal-menus.module.ts
@@ -7,9 +7,18 @@ import { MealMenusController } from './meal-menus.controller';
 import { MealMenuRepository } from './meal-menus.repository';
 import { MealMenusService } from './meal-menus.service';
 import { MealMenuComponent } from './entities/meal-menu-component.entity';
+import { MealMenuComponentMapping } from './entities/meal-menu-component-mapping.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MealMenu, MealMenuReaction, MealMenuComponent]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([
+      MealMenu,
+      MealMenuReaction,
+      MealMenuComponent,
+      MealMenuComponentMapping,
+    ]),
+    AuthModule,
+  ],
   controllers: [MealMenusController],
   providers: [MealMenuRepository, MealMenusService],
 })

--- a/src/meal-menus/meal-menus.module.ts
+++ b/src/meal-menus/meal-menus.module.ts
@@ -6,9 +6,10 @@ import { MealMenuReaction } from './entities/meal-menu-reaction.entity';
 import { MealMenusController } from './meal-menus.controller';
 import { MealMenuRepository } from './meal-menus.repository';
 import { MealMenusService } from './meal-menus.service';
+import { MealMenuComponent } from './entities/meal-menu-component.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MealMenu, MealMenuReaction]), AuthModule],
+  imports: [TypeOrmModule.forFeature([MealMenu, MealMenuReaction, MealMenuComponent]), AuthModule],
   controllers: [MealMenusController],
   providers: [MealMenuRepository, MealMenusService],
 })

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -40,7 +40,11 @@ export class MealMenuRepository {
     // more complex query composition.
     return this.mealMenuRepository.findOne({
       where: { id: mealMenuId },
-      relations: { components: true },
+      relations: {
+        mealMenuComponentMappings: {
+          mealMenuComponent: true,
+        },
+      },
     });
   }
 

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -38,7 +38,10 @@ export class MealMenuRepository {
   async findById(mealMenuId: number): Promise<MealMenu | null> {
     // Single-record lookups stay on repository helpers unless they need joins or
     // more complex query composition.
-    return this.mealMenuRepository.findOneBy({ id: mealMenuId });
+    return this.mealMenuRepository.findOne({
+      where: { id: mealMenuId },
+      relations: { components: true },
+    });
   }
 
   async findRankings(params: FindMealMenuRankingsParams): Promise<MealMenu[]> {

--- a/test/meal-menus.e2e-spec.ts
+++ b/test/meal-menus.e2e-spec.ts
@@ -221,6 +221,7 @@ describe('Meal Menus (e2e)', () => {
         calorie: 750,
         likeCount: 5,
         dislikeCount: 2,
+        components: [],
       });
     });
 

--- a/test/test-app.ts
+++ b/test/test-app.ts
@@ -18,6 +18,7 @@ import { Comment } from '../src/comments/entities/comment.entity';
 import { Friend } from '../src/friends/entities/friend.entity';
 import { MealMenuModule } from '../src/meal-menus/meal-menus.module';
 import { FriendModule } from '../src/friends/friends.module';
+import { MealMenuComponent } from '../src/meal-menus/entities/meal-menu-component.entity';
 import { MealMenuReaction } from '../src/meal-menus/entities/meal-menu-reaction.entity';
 import { MealMenu } from '../src/meal-menus/entities/meal-menu.entity';
 import { PostCategory } from '../src/post-categories/entities/post-category.entity';
@@ -41,6 +42,7 @@ const TEST_ENTITIES = [
   Comment,
   CommentLike,
   MealMenu,
+  MealMenuComponent,
   MealMenuReaction,
 ];
 


### PR DESCRIPTION
## 연관된 이슈

- #이슈번호

## 📝 작업 내용

- [x] 학식 테이블과 학식 구성 테이블 다대다 관계 설정
- [x] 학식 구성 `MealMenuComponent` entity 추가
- [x] 중간 엔티티 `MealMenuComponentMapping` entity 추가
- [x] 학식 상세 응답에 구성 요소 포함
- [x] 관련 migration 추가
- [x] 테스트 추가/수정
