### PR TITLE
학식 수정 API 구현

### DIFF
--- a/src/meal-menus/dto/update-meal-menu.dto.ts
+++ b/src/meal-menus/dto/update-meal-menu.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateMealMenuDto } from './create-meal-menu.dto';
+
+export class UpdateMealMenuDto extends PartialType(CreateMealMenuDto) {}

--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -1,5 +1,6 @@
 import { JwtAuthGuard } from './../auth/guards/jwt-auth.guard';
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -7,6 +8,7 @@ import {
   HttpStatus,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -16,6 +18,7 @@ import {
   ApiBearerAuth,
   ApiCreatedResponse,
   ApiForbiddenResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -37,6 +40,7 @@ import { Roles } from 'src/auth/decorators/role.decorator';
 import { UserRole } from 'src/users/entities/user.entity';
 import { RolesGuard } from 'src/auth/guards/role.guard';
 import { CreateMealMenuDto } from './dto/create-meal-menu.dto';
+import { UpdateMealMenuDto } from './dto/update-meal-menu.dto';
 
 @ApiTags('MealMenu')
 @Controller('meal-menus')
@@ -112,6 +116,31 @@ export class MealMenusController {
   ): Promise<MealMenuReactionResponseDto> {
     const mealMenu = await this.mealMenusService.dislikeMealMenu(currentUser.userId, mealMenuId);
     return this.toReactionResponse(ActionType.DISLIKE, mealMenu);
+  }
+
+  @Patch(':mealMenuId')
+  @Roles(UserRole.ADMIN)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '학식 수정' })
+  @ApiOkResponse({ type: MealMenuDetailResponseDto, description: '학식 수정 성공' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 학식을 수정하려는 경우' })
+  @ApiBadRequestResponse({ description: '학식 수정 요청 값이 올바르지 않은 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  @ApiForbiddenResponse({ description: '관리자 권한이 없는 사용자가 요청한 경우' })
+  async updateMealMenu(
+    @Body() updateMealMenuDto: UpdateMealMenuDto,
+    @Param('mealMenuId', ParseIntPipe) mealMenuId: number,
+  ): Promise<MealMenuDetailResponseDto> {
+    if (Object.keys(updateMealMenuDto).length < 1)
+      throw new BadRequestException('수정할 값이 없습니다.');
+
+    const updatedMealMenu = await this.mealMenusService.updateMealMenu(
+      mealMenuId,
+      updateMealMenuDto,
+    );
+
+    return this.toDetailResponse(updatedMealMenu);
   }
 
   private toListResponse(mealMenus: MealMenu[]): MealMenuListResponseDto {

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -7,11 +7,13 @@ import {
   InsertResult,
   Repository,
   SelectQueryBuilder,
+  DeleteResult,
+  UpdateResult,
 } from 'typeorm';
 import { MealMenu, MealType } from './entities/meal-menu.entity';
 import { ActionType, MealMenuReaction } from './entities/meal-menu-reaction.entity';
 import { User } from '../users/entities/user.entity';
-import { CreateMealMenuProps } from './types/meal-menu.type';
+import { CreateMealMenuProps, UpdateMealMenuProps } from './types/meal-menu.type';
 import { MealMenuComponent } from './entities/meal-menu-component.entity';
 import { MealMenuComponentMapping } from './entities/meal-menu-component-mapping.entity';
 
@@ -183,6 +185,21 @@ export class MealMenuRepository {
         })),
       )
       .execute();
+  }
+
+  async updateMealMenu(
+    mealMenuId: number,
+    mealMenuProps: UpdateMealMenuProps,
+    manager: EntityManager,
+  ): Promise<UpdateResult> {
+    return await manager.update(MealMenu, mealMenuId, mealMenuProps);
+  }
+
+  async deleteComponentMappingByMealMenuId(
+    mealMenuId: number,
+    manager: EntityManager,
+  ): Promise<DeleteResult> {
+    return await manager.delete(MealMenuComponentMapping, { mealMenu: { id: mealMenuId } });
   }
 
   private async persistReaction(

--- a/src/meal-menus/meal-menus.service.spec.ts
+++ b/src/meal-menus/meal-menus.service.spec.ts
@@ -2,7 +2,7 @@ import { DataSource, EntityManager, InsertResult } from 'typeorm';
 import { MealType } from './entities/meal-menu.entity';
 import { MealMenuRepository } from './meal-menus.repository';
 import { MealMenusService } from './meal-menus.service';
-import { CreateMealMenuProps } from './types/meal-menu.type';
+import { CreateMealMenuProps, UpdateMealMenuProps } from './types/meal-menu.type';
 
 type Component = {
   id: number;
@@ -28,6 +28,8 @@ describe('MealMenusService', () => {
     | 'findExistingComponentsByName'
     | 'createMealMenuComponent'
     | 'createMealMenuComponentMapping'
+    | 'deleteComponentMappingByMealMenuId'
+    | 'updateMealMenu'
     | 'findById'
   >;
   let components: Component[];
@@ -36,7 +38,7 @@ describe('MealMenusService', () => {
 
   const manager = {} as EntityManager;
   const dataSource = {
-    transaction: async (callback: (manager: EntityManager) => Promise<number>) => callback(manager),
+    transaction: async <T>(callback: (manager: EntityManager) => Promise<T>) => callback(manager),
   } as DataSource;
 
   beforeEach(() => {
@@ -87,6 +89,20 @@ describe('MealMenusService', () => {
           );
         },
       ),
+
+      deleteComponentMappingByMealMenuId: jest.fn(async (mealMenuId: number) => {
+        mappings = mappings.filter((mapping) => mapping.mealMenuId !== mealMenuId);
+      }),
+
+      updateMealMenu: jest.fn(async (mealMenuId: number, props: UpdateMealMenuProps) => {
+        const mealMenu = mealMenus.find((item) => item.id === mealMenuId);
+
+        if (!mealMenu) return { affected: 0 } as never;
+
+        Object.assign(mealMenu, props);
+
+        return { affected: 1 } as never;
+      }),
 
       findById: jest.fn(async (mealMenuId: number) => {
         const mealMenu = mealMenus.find((item) => item.id === mealMenuId);
@@ -164,6 +180,96 @@ describe('MealMenusService', () => {
           { mealMenuComponent: { id: 1, name: '포기김치' } },
         ],
       });
+    });
+  });
+
+  describe('updateMealMenu', () => {
+    it('학식 기본 정보와 구성 요소를 수정한다', async () => {
+      mealMenus.push({
+        id: 1,
+        schoolInfo: '인덕대학교',
+        mealType: MealType.LUNCH,
+        menuName: '기존식단',
+        price: 5000,
+        calorie: 650,
+        likeCount: 2,
+        dislikeCount: 1,
+      });
+      components.push(
+        { id: 1, name: '백미밥' },
+        { id: 2, name: '포기김치' },
+      );
+      mappings.push(
+        { mealMenuId: 1, componentId: 1 },
+        { mealMenuId: 1, componentId: 2 },
+      );
+
+      const input = {
+        mealType: MealType.DINNER,
+        menuName: '수정식단',
+        price: 6500,
+        calorie: 900,
+        components: '흑미밥 포기김치 된장국',
+      };
+
+      const result = await mealMenusService.updateMealMenu(1, input);
+
+      expect(result).toMatchObject({
+        id: 1,
+        schoolInfo: '인덕대학교',
+        mealType: MealType.DINNER,
+        menuName: '수정식단',
+        price: 6500,
+        calorie: 900,
+        likeCount: 2,
+        dislikeCount: 1,
+        mealMenuComponentMappings: [
+          { mealMenuComponent: { id: 3, name: '흑미밥' } },
+          { mealMenuComponent: { id: 2, name: '포기김치' } },
+          { mealMenuComponent: { id: 4, name: '된장국' } },
+        ],
+      });
+    });
+
+    it('구성 요소가 없으면 학식 기본 정보만 수정한다', async () => {
+      mealMenus.push({
+        id: 1,
+        schoolInfo: '인덕대학교',
+        mealType: MealType.LUNCH,
+        menuName: '기존식단',
+        price: 5000,
+        calorie: 650,
+        likeCount: 0,
+        dislikeCount: 0,
+      });
+      components.push({ id: 1, name: '백미밥' });
+      mappings.push({ mealMenuId: 1, componentId: 1 });
+
+      const input = {
+        menuName: '이름만수정',
+        price: 5500,
+      };
+
+      const result = await mealMenusService.updateMealMenu(1, input);
+
+      expect(result).toMatchObject({
+        id: 1,
+        mealType: MealType.LUNCH,
+        menuName: '이름만수정',
+        price: 5500,
+        calorie: 650,
+        mealMenuComponentMappings: [{ mealMenuComponent: { id: 1, name: '백미밥' } }],
+      });
+    });
+
+    it('존재하지 않는 학식이면 예외를 던진다', async () => {
+      const input = {
+        menuName: '수정식단',
+      };
+
+      await expect(mealMenusService.updateMealMenu(999, input)).rejects.toThrow(
+        'Meal menu not found.',
+      );
     });
   });
 });

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -6,7 +6,8 @@ import { MealMenu } from './entities/meal-menu.entity';
 import { MealMenuRepository } from './meal-menus.repository';
 import { CreateMealMenuDto } from './dto/create-meal-menu.dto';
 import { DataSource, EntityManager } from 'typeorm';
-import { CreateMealMenuProps } from './types/meal-menu.type';
+import { CreateMealMenuProps, UpdateMealMenuProps } from './types/meal-menu.type';
+import { UpdateMealMenuDto } from './dto/update-meal-menu.dto';
 
 @Injectable()
 export class MealMenusService {
@@ -16,7 +17,7 @@ export class MealMenusService {
   ) {}
 
   async createMealMenu(createMealMenuDto: CreateMealMenuDto): Promise<MealMenu> {
-    const { mealMenuProps, componentNames } = this.buildMealMenuProps(createMealMenuDto);
+    const { mealMenuProps, componentNames } = this.buildCreateMealMenuProps(createMealMenuDto);
 
     const mealMenuId = await this.dataSource.transaction(async (manager) => {
       const newMealMenu = await this.mealMenuRepository.createMealMenu(mealMenuProps, manager);
@@ -62,6 +63,33 @@ export class MealMenusService {
     return this.applyReactionOrFail(userId, mealMenuId, ActionType.DISLIKE);
   }
 
+  async updateMealMenu(
+    mealMenuId: number,
+    updateMealMenuDto: UpdateMealMenuDto,
+  ): Promise<MealMenu> {
+    await this.findMealMenuOrFail(mealMenuId);
+
+    const { mealMenuProps, componentNames } = this.buildUpdateMealMenuProps(updateMealMenuDto);
+
+    await this.dataSource.transaction(async (manager) => {
+      if (componentNames.length > 0) {
+        await this.mealMenuRepository.deleteComponentMappingByMealMenuId(mealMenuId, manager);
+
+        const componentIds = await this.findOrCreateComponentIds(componentNames, manager);
+
+        await this.mealMenuRepository.createMealMenuComponentMapping(
+          mealMenuId,
+          componentIds,
+          manager,
+        );
+      }
+
+      await this.mealMenuRepository.updateMealMenu(mealMenuId, mealMenuProps, manager);
+    });
+
+    return this.findMealMenuById(mealMenuId);
+  }
+
   private async applyReactionOrFail(
     userId: number,
     mealMenuId: number,
@@ -84,13 +112,24 @@ export class MealMenusService {
     return mealMenu;
   }
 
-  private buildMealMenuProps(createMealMenuDto: CreateMealMenuDto): {
+  private buildCreateMealMenuProps(createMealMenuDto: CreateMealMenuDto): {
     mealMenuProps: CreateMealMenuProps;
     componentNames: string[];
   } {
     const { components, ...mealMenuProps } = createMealMenuDto;
 
     const componentNames = components.split(' ').filter(Boolean);
+
+    return { mealMenuProps, componentNames };
+  }
+
+  private buildUpdateMealMenuProps(updateMealMenuDto: UpdateMealMenuDto): {
+    mealMenuProps: UpdateMealMenuProps;
+    componentNames: string[];
+  } {
+    const { components, ...mealMenuProps } = updateMealMenuDto;
+
+    const componentNames = components ? components.split(' ').filter(Boolean) : [];
 
     return { mealMenuProps, componentNames };
   }

--- a/src/meal-menus/types/meal-menu.type.ts
+++ b/src/meal-menus/types/meal-menu.type.ts
@@ -7,3 +7,5 @@ export type CreateMealMenuProps = {
   price: number;
   calorie: number;
 };
+
+export type UpdateMealMenuProps = Partial<CreateMealMenuProps>;

--- a/test/meal-menus.e2e-spec.ts
+++ b/test/meal-menus.e2e-spec.ts
@@ -161,6 +161,185 @@ describe('Meal Menus (e2e)', () => {
     });
   });
 
+  describe('Update', () => {
+    it('ADMIN 사용자는 학식을 수정할 수 있다', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'update-admin@example.com',
+        'update-admin',
+      );
+
+      const createResponse = await request(app.getHttpServer())
+        .post('/meal-menus')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          schoolInfo: '인덕대학교 학생식당',
+          mealType: MealType.LUNCH,
+          menuName: '제육덮밥',
+          price: 5000,
+          calorie: 550,
+          components: '밥 미역국 제육볶음 배추김치',
+        });
+
+      const input = {
+        mealType: MealType.DINNER,
+        menuName: '돈까스정식',
+        price: 6500,
+        calorie: 880,
+        components: '밥 우동 돈까스 깍두기',
+      };
+
+      const response = await request(app.getHttpServer())
+        .patch(`/meal-menus/${createResponse.body.id}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(input);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        id: createResponse.body.id,
+        mealType: MealType.DINNER,
+        menuName: '돈까스정식',
+        price: 6500,
+        calorie: 880,
+        likeCount: 0,
+        dislikeCount: 0,
+        components: ['밥', '우동', '돈까스', '깍두기'],
+      });
+    });
+
+    it('components 없이 수정하면 기존 구성 요소를 유지한다', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'partial-update-admin@example.com',
+        'partial-update-admin',
+      );
+
+      const createResponse = await request(app.getHttpServer())
+        .post('/meal-menus')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          schoolInfo: '인덕대학교 학생식당',
+          mealType: MealType.LUNCH,
+          menuName: '제육덮밥',
+          price: 5000,
+          calorie: 550,
+          components: '밥 미역국 제육볶음 배추김치',
+        });
+
+      const response = await request(app.getHttpServer())
+        .patch(`/meal-menus/${createResponse.body.id}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          menuName: '제육정식',
+          price: 6000,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        id: createResponse.body.id,
+        mealType: MealType.LUNCH,
+        menuName: '제육정식',
+        price: 6000,
+        calorie: 550,
+        likeCount: 0,
+        dislikeCount: 0,
+        components: ['밥', '미역국', '제육볶음', '배추김치'],
+      });
+    });
+
+    it('인증 없이 학식 수정 요청 시 401', async () => {
+      const response = await request(app.getHttpServer()).patch('/meal-menus/1').send({
+        menuName: '돈까스정식',
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 401,
+        message: 'Unauthorized',
+      });
+    });
+
+    it('USER 사용자가 학식 수정 요청 시 403', async () => {
+      const accessToken = await signupAndGetAccessToken('update-user@example.com', 'update-user');
+
+      const response = await request(app.getHttpServer())
+        .patch('/meal-menus/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          menuName: '돈까스정식',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 403,
+        message: AUTH_ERROR_MESSAGES.accessDenied,
+      });
+    });
+
+    it('존재하지 않는 학식 수정 요청 시 404', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'missing-update-admin@example.com',
+        'missing-update-admin',
+      );
+
+      const response = await request(app.getHttpServer())
+        .patch('/meal-menus/999999')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          menuName: '돈까스정식',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 404,
+        message: 'Meal menu not found.',
+      });
+    });
+
+    it('빈 body로 학식 수정 요청 시 400', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'empty-update-admin@example.com',
+        'empty-update-admin',
+      );
+
+      const response = await request(app.getHttpServer())
+        .patch('/meal-menus/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 400,
+        message: '수정할 값이 없습니다.',
+      });
+    });
+
+    it('잘못된 mealType으로 학식 수정 요청 시 400', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'invalid-update-admin@example.com',
+        'invalid-update-admin',
+      );
+
+      const response = await request(app.getHttpServer())
+        .patch('/meal-menus/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          mealType: 'INVALID',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 400,
+        message: [
+          'mealType must be one of the following values: BREAKFAST, LUNCH, DINNER, ALL',
+        ],
+      });
+    });
+  });
+
   describe('List', () => {
     it('학식 목록 조회 성공', async () => {
       const mealMenu = await createMealMenu({


### PR DESCRIPTION
## 연관된 이슈

- #169 

## 📝 작업 내용

- [x] PATCH /meal-menus/:id 학식 수정 API 구현
- [x] 학식 수정 DTO 정의
- [x] 학식 수정 Swagger 문서화 추가
- [x] role이 ADMIN인 사용자만 수정 가능하도록 인증 적용
- [x] 존재하는 학식인지 검증
- [x] body가 비었는지 검증
- [x] components 수정 시 기존 매핑 삭제 후 새 매핑 생성
- [x] 학식 수정 단위 테스트 추가
- [x] 학식 수정 e2e 테스트 추가