### PR TITLE
학식 삭제 API 구현

### DIFF
--- a/src/meal-menus/meal-menus.controller.ts
+++ b/src/meal-menus/meal-menus.controller.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -18,6 +19,7 @@ import {
   ApiBearerAuth,
   ApiCreatedResponse,
   ApiForbiddenResponse,
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -141,6 +143,20 @@ export class MealMenusController {
     );
 
     return this.toDetailResponse(updatedMealMenu);
+  }
+
+  @Delete(':mealMenuId')
+  @HttpCode(204)
+  @Roles(UserRole.ADMIN)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '학식 삭제' })
+  @ApiNoContentResponse({ description: '학식 삭제 성공, 응답 본문은 반환되지 않음' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 학식을 삭제하려는 경우' })
+  @ApiUnauthorizedResponse({ description: '로그인하지 않은 사용자가 요청한 경우' })
+  @ApiForbiddenResponse({ description: '관리자 권한이 없는 사용자가 요청한 경우' })
+  async deleteMealMenu(@Param('mealMenuId', ParseIntPipe) mealMenuId: number): Promise<void> {
+    return await this.mealMenusService.deleteMealMenu(mealMenuId);
   }
 
   private toListResponse(mealMenus: MealMenu[]): MealMenuListResponseDto {

--- a/src/meal-menus/meal-menus.repository.ts
+++ b/src/meal-menus/meal-menus.repository.ts
@@ -202,6 +202,10 @@ export class MealMenuRepository {
     return await manager.delete(MealMenuComponentMapping, { mealMenu: { id: mealMenuId } });
   }
 
+  async deleteMealMenu(mealMenuId: number): Promise<void> {
+    await this.mealMenuRepository.delete(mealMenuId);
+  }
+
   private async persistReaction(
     repository: Repository<MealMenuReaction>,
     existingReaction: MealMenuReaction | null,

--- a/src/meal-menus/meal-menus.service.spec.ts
+++ b/src/meal-menus/meal-menus.service.spec.ts
@@ -30,6 +30,7 @@ describe('MealMenusService', () => {
     | 'createMealMenuComponentMapping'
     | 'deleteComponentMappingByMealMenuId'
     | 'updateMealMenu'
+    | 'deleteMealMenu'
     | 'findById'
   >;
   let components: Component[];
@@ -102,6 +103,11 @@ describe('MealMenusService', () => {
         Object.assign(mealMenu, props);
 
         return { affected: 1 } as never;
+      }),
+
+      deleteMealMenu: jest.fn(async (mealMenuId: number) => {
+        mealMenus = mealMenus.filter((mealMenu) => mealMenu.id !== mealMenuId);
+        mappings = mappings.filter((mapping) => mapping.mealMenuId !== mealMenuId);
       }),
 
       findById: jest.fn(async (mealMenuId: number) => {
@@ -268,6 +274,35 @@ describe('MealMenusService', () => {
       };
 
       await expect(mealMenusService.updateMealMenu(999, input)).rejects.toThrow(
+        'Meal menu not found.',
+      );
+    });
+  });
+
+  describe('deleteMealMenu', () => {
+    it('학식을 삭제한다', async () => {
+      mealMenus.push({
+        id: 1,
+        schoolInfo: '인덕대학교',
+        mealType: MealType.LUNCH,
+        menuName: '삭제할식단',
+        price: 5000,
+        calorie: 650,
+        likeCount: 0,
+        dislikeCount: 0,
+      });
+      components.push({ id: 1, name: '백미밥' });
+      mappings.push({ mealMenuId: 1, componentId: 1 });
+
+      await mealMenusService.deleteMealMenu(1);
+
+      await expect(mealMenusService.findMealMenuById(1)).rejects.toThrow(
+        'Meal menu not found.',
+      );
+    });
+
+    it('존재하지 않는 학식이면 예외를 던진다', async () => {
+      await expect(mealMenusService.deleteMealMenu(999)).rejects.toThrow(
         'Meal menu not found.',
       );
     });

--- a/src/meal-menus/meal-menus.service.ts
+++ b/src/meal-menus/meal-menus.service.ts
@@ -90,6 +90,12 @@ export class MealMenusService {
     return this.findMealMenuById(mealMenuId);
   }
 
+  async deleteMealMenu(mealMenuId: number): Promise<void> {
+    await this.findMealMenuOrFail(mealMenuId);
+
+    await this.mealMenuRepository.deleteMealMenu(mealMenuId);
+  }
+
   private async applyReactionOrFail(
     userId: number,
     mealMenuId: number,

--- a/test/meal-menus.e2e-spec.ts
+++ b/test/meal-menus.e2e-spec.ts
@@ -340,6 +340,100 @@ describe('Meal Menus (e2e)', () => {
     });
   });
 
+  describe('Delete', () => {
+    it('ADMIN 사용자는 학식을 삭제할 수 있다', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'delete-admin@example.com',
+        'delete-admin',
+      );
+
+      const createResponse = await request(app.getHttpServer())
+        .post('/meal-menus')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          schoolInfo: '인덕대학교 학생식당',
+          mealType: MealType.LUNCH,
+          menuName: '제육덮밥',
+          price: 5000,
+          calorie: 550,
+          components: '밥 미역국 제육볶음 배추김치',
+        });
+
+      const mappingCountBeforeDelete = await dataSource
+        .getRepository(MealMenuComponentMapping)
+        .count({
+          where: {
+            mealMenu: { id: createResponse.body.id },
+          },
+        });
+
+      const response = await request(app.getHttpServer())
+        .delete(`/meal-menus/${createResponse.body.id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      const detailResponse = await request(app.getHttpServer()).get(
+        `/meal-menus/${createResponse.body.id}`,
+      );
+      const mappingCountAfterDelete = await dataSource
+        .getRepository(MealMenuComponentMapping)
+        .count({
+          where: {
+            mealMenu: { id: createResponse.body.id },
+          },
+        });
+
+      expect(mappingCountBeforeDelete).toBe(4);
+      expect(response.status).toBe(204);
+      expect(response.body).toEqual({});
+      expect(detailResponse.status).toBe(404);
+      expect(mappingCountAfterDelete).toBe(0);
+    });
+
+    it('인증 없이 학식 삭제 요청 시 401', async () => {
+      const response = await request(app.getHttpServer()).delete('/meal-menus/1');
+
+      expect(response.status).toBe(401);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 401,
+        message: 'Unauthorized',
+      });
+    });
+
+    it('USER 사용자가 학식 삭제 요청 시 403', async () => {
+      const accessToken = await signupAndGetAccessToken('delete-user@example.com', 'delete-user');
+
+      const response = await request(app.getHttpServer())
+        .delete('/meal-menus/1')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 403,
+        message: AUTH_ERROR_MESSAGES.accessDenied,
+      });
+    });
+
+    it('존재하지 않는 학식 삭제 요청 시 404', async () => {
+      const accessToken = await signupAndGetAdminAccessToken(
+        'missing-delete-admin@example.com',
+        'missing-delete-admin',
+      );
+
+      const response = await request(app.getHttpServer())
+        .delete('/meal-menus/999999')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toEqual({
+        statusCode: 404,
+        message: 'Meal menu not found.',
+      });
+    });
+  });
+
   describe('List', () => {
     it('학식 목록 조회 성공', async () => {
       const mealMenu = await createMealMenu({


### PR DESCRIPTION
## 연관된 이슈

- #172 

## 📝 작업 내용

- [x] ADMIN 권한 사용자만 삭제 가능하도록 적용
- [x] 존재하지 않는 학식 삭제 예외 처리
- [x] 학식 삭제 시 구성 요소 매핑 데이터 cascade 삭제
- [x] 학식 삭제 Swagger 문서화 추가
- [x] 학식 삭제 서비스 테스트 추가
- [x] 학식 삭제 e2e 테스트 추가
- [x] 기존 학식 테스트 통과 확인
